### PR TITLE
[0.9.0] Adds command to see users with available GR tokens or bombs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - -->
 
+## [0.9.0] - 2025-05-09
+
+Special thanks to `WolfLord 5's` for the feature request.
+
+### Added
+
+-   `/available-tokens-bombs` command that returns a list of users who have bombs or guild raid tokens available
+
 ## [0.8.5] - 2025-05-08
 
 `/get-member-ids` result is now only visible to the user who called the command.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "0.8.5",
+    "version": "0.9.0",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/client/HominaTacticusClient.ts
+++ b/src/client/HominaTacticusClient.ts
@@ -66,6 +66,30 @@ class HominaTacticusClient {
 
         return body;
     }
+
+    async getGuildRaidByCurrentSeason(
+        apiKey: string
+    ): Promise<GuildRaidResponse> {
+        try {
+            const response = await fetch(`${this.baseUrl}/guildRaid`, {
+                method: "GET",
+                headers: {
+                    Accept: "application/json",
+                    "X-API-KEY": `${apiKey}`,
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error(`GET request failed: ${response.statusText}`);
+            }
+
+            const body = (await response.json()) as GuildRaidResponse;
+
+            return body;
+        } catch (error) {
+            throw new Error(`GET request failed: ${error}`);
+        }
+    }
 }
 
 // Typeguards because TS shenanigans

--- a/src/commands/guild/availableTokensBombs.ts
+++ b/src/commands/guild/availableTokensBombs.ts
@@ -1,0 +1,90 @@
+import { logger } from "@/lib";
+import { GuildService } from "@/lib/services/GuildService.ts";
+import {
+    ChatInputCommandInteraction,
+    EmbedBuilder,
+    SlashCommandBuilder,
+} from "discord.js";
+
+export const cooldown = 5;
+
+export const data = new SlashCommandBuilder()
+    .setName("available-tokens-bombs")
+    .setDescription(
+        "Get an overview of how many guild raid tokens and bombs each member has available"
+    );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply();
+
+    const service = new GuildService();
+
+    logger.info(
+        `${interaction.user.username} attempting to use /available-tokens-bombs`
+    );
+
+    try {
+        const result = await service.getAvailableTokensAndBombs(
+            interaction.user.id
+        );
+
+        if (
+            !result ||
+            typeof result !== "object" ||
+            Object.keys(result).length === 0
+        ) {
+            await interaction.editReply({
+                content:
+                    "No data found for the current season. Ensure you are registered and have the correct permissions.",
+            });
+            return;
+        }
+
+        const filtered = Object.entries(result).filter(([, available]) => {
+            return available.tokens > 0 || available.bombs > 0;
+        });
+
+        const table = filtered
+            .map(
+                ([userId, available]) =>
+                    `\`${userId}\`: ${available.tokens} tokens, ${available.bombs} bombs `
+            )
+            .join("\n");
+
+        if (table.length === 0) {
+            await interaction.editReply({
+                content: "No members have available tokens or bombs right now.",
+            });
+            return;
+        }
+
+        const embed = new EmbedBuilder()
+            .setColor("#0099ff")
+            .setTitle("Available Tokens and Bombs")
+            .setDescription(
+                "Here is the list of members with available tokens and bombs:\n"
+            )
+            .setFields([
+                {
+                    name: "Available Tokens and Bombs",
+                    value: table,
+                },
+            ])
+            .setTimestamp()
+            .setFooter({
+                text: "Data fetched from the guild raid API",
+            });
+
+        await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+        logger.error(
+            error,
+            `Error occured in available-tokens-bombs by ${interaction.user.username}`
+        );
+        await interaction.editReply({
+            content:
+                "An error occurred while fetching the data. Please try again later or contact the Bot developer if the problem persists.",
+        });
+        return;
+    }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -179,3 +179,7 @@ export function sortGuildRaidResultDesc(data: GuildRaidResult[]) {
 export function sortTokensUsed(data: TokensUsed[]) {
     return data.sort((a, b) => b.tokens - a.tokens);
 }
+
+export function getUnixTimestamp(date: Date) {
+    return Math.floor(date.getTime() / 1000);
+}

--- a/src/models/types/GuildRaidAvailable.ts
+++ b/src/models/types/GuildRaidAvailable.ts
@@ -1,0 +1,4 @@
+export interface GuildRaidAvailable {
+    bombs: number;
+    tokens: number;
+}

--- a/src/models/types/Raid.ts
+++ b/src/models/types/Raid.ts
@@ -14,8 +14,8 @@ export interface Raid {
     rarity: Rarity;
     damageDealt: number;
     damageType: DamageType;
-    startedOn: Date;
-    completedOn: Date;
+    startedOn: number;
+    completedOn: number;
     heroDetails: PublicHeroDetail[];
     machineOfWarDetails: PublicHeroDetail;
     globalConfigHash: string;

--- a/src/models/types/TokensAndBombs.ts
+++ b/src/models/types/TokensAndBombs.ts
@@ -1,0 +1,6 @@
+import type { Raid } from "./Raid";
+
+export interface TokensAndBombs {
+    bombs: Raid[];
+    tokens: Raid[];
+}

--- a/src/models/types/index.ts
+++ b/src/models/types/index.ts
@@ -4,3 +4,5 @@ export * from "./GuildRaidResponse";
 export * from "./Raid";
 export * from "./PublicHeroDetail";
 export * from "./GuildRaidResult";
+export * from "./TokensAndBombs";
+export * from "./GuildRaidAvailable";


### PR DESCRIPTION
This pull request introduces a new feature to the project: the `/available-tokens-bombs` command, which provides an overview of guild members' available raid tokens and bombs. Additionally, it includes supporting changes such as API integration, utility functions, and type definitions. The most important changes are outlined below:

### New Feature: `/available-tokens-bombs` Command
* Added a new command `available-tokens-bombs` in `src/commands/guild/availableTokensBombs.ts`. This command fetches and displays a list of guild members with their available tokens and bombs using an embed message.

### API Integration
* Implemented `getGuildRaidByCurrentSeason` method in `HominaTacticusClient` to fetch guild raid data from the API.
* Added `getAvailableTokensAndBombs` method in `GuildService` to process raid data and calculate available tokens and bombs for each user.

### Utility and Type Enhancements
* Introduced a utility function `getUnixTimestamp` in `src/lib/utils.ts` to convert dates to Unix timestamps.
* Added new type definitions: `GuildRaidAvailable` in `src/models/types/GuildRaidAvailable.ts` and `TokensAndBombs` in `src/models/types/TokensAndBombs.ts`. These types represent the structure of available tokens and bombs data. [[1]](diffhunk://#diff-711a74c00ea13243529c5c3fe783a6c86f0e608121ff01489621b93f49576c7fR1-R4) [[2]](diffhunk://#diff-ce21888249360172147eabe96e323a8b7de6ecc78eff7011f25897be60f70e99R1-R6)
* Updated `Raid` type to use Unix timestamps (`number`) instead of `Date` for `startedOn` and `completedOn` fields.

### Documentation and Versioning
* Updated `CHANGELOG.md` to include the new `/available-tokens-bombs` command under version `0.9.0`.
* Bumped project version from `0.8.5` to `0.9.0` in `package.json`.