### PR TITLE
Stats command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - -->
 
+## [0.14.0] - 2025-05-28
+
+### Added
+
+-   `/bot-stats` - An initial bot stats command that shows the current uptime, count of servers running the bot and the number of registered users. (60 second cooldown).
+
 ## [0.13.1] - 2025-05-28
 
 Hotfix of the register command not properly encrypting tokens.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "0.13.1",
+    "version": "0.14.0",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/commands/utility/stats.ts
+++ b/src/commands/utility/stats.ts
@@ -6,7 +6,7 @@ import {
     SlashCommandBuilder,
 } from "discord.js";
 
-export const cooldown = 5;
+export const cooldown = 60;
 
 export const data = new SlashCommandBuilder()
     .setName("bot-stats")

--- a/src/lib/DatabaseController.ts
+++ b/src/lib/DatabaseController.ts
@@ -173,6 +173,21 @@ export class DatabaseController {
         }
     }
 
+    public async getNumberOfUsers(): Promise<number> {
+        try {
+            const res = await this.sequelize.models[
+                "discordApiTokenMappings"
+            ]?.count();
+            return res || 0;
+        } catch (error) {
+            logger.error(
+                error,
+                "Error retrieving number of users from database"
+            );
+            return 0;
+        }
+    }
+
     public async getUserToken(userId: string): Promise<string | null> {
         try {
             const result = await this.sequelize.models[


### PR DESCRIPTION
This pull request introduces a new bot stats command (`/bot-stats`) and updates the project version to `0.14.0`. The changes include adding the command implementation, updating the database controller to support user count retrieval, and reflecting the new version in the changelog and `package.json`.

### New Feature: Bot Stats Command

* **`src/commands/utility/stats.ts`**: Added the `/bot-stats` command to display bot statistics, including uptime, server count, and registered user count. The command has a 60-second cooldown and uses an ephemeral reply for privacy.
* **`src/lib/DatabaseController.ts`**: Introduced the `getNumberOfUsers` method to retrieve the count of registered users from the database, supporting the `/bot-stats` command functionality.

### Version Update

* **`CHANGELOG.md`**: Added an entry for version `0.14.0`, documenting the new `/bot-stats` command.
* **`package.json`**: Updated the project version from `0.13.1` to `0.14.0`.