### PR TITLE
Update bot presence and bump version to 0.14.1

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,9 @@
-import { Client, GatewayIntentBits, Collection } from "discord.js";
+import {
+    Client,
+    GatewayIntentBits,
+    Collection,
+    ActivityType,
+} from "discord.js";
 import * as path from "path";
 import * as fs from "fs";
 import { dbController, logger } from "@/lib";
@@ -14,6 +19,15 @@ console.log("Starting Discord bot...");
 
 const client = new IClient({
     intents: [GatewayIntentBits.Guilds],
+    presence: {
+        activities: [
+            {
+                type: ActivityType.Custom,
+                name: "Worshiping the machine spirit",
+            },
+        ],
+        status: "online",
+    },
 });
 
 // Load commands and start the bot
@@ -53,6 +67,8 @@ const startBot = async () => {
                 client.on(event.name, (...args) => event.execute(...args));
             }
         }
+
+        client.user?.setActivity("test", { type: ActivityType.Custom });
 
         // Log in to Discord
         await client.login(process.env.BOT_TOKEN!);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "0.14.0",
+    "version": "0.14.1",
     "module": "index.ts",
     "type": "module",
     "private": true,


### PR DESCRIPTION
This pull request introduces enhancements to the Discord bot's presence configuration, updates its activity settings, and includes a minor version bump in `package.json`. The most important changes are the addition of a custom activity and status for the bot's presence and the update to the bot's version.

### Discord bot presence enhancements:

* [`index.ts`](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122R22-R30): Added a `presence` configuration to the `client` initialization, specifying a custom activity (`"Worshiping the machine spirit"`) and setting the bot's status to `"online"`.
* [`index.ts`](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122R71-R72): Added a line to dynamically set the bot's activity to `"test"` with a custom activity type after the bot starts.

### Miscellaneous updates:

* [`index.ts`](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L1-R6): Imported `ActivityType` from `discord.js` to support the new presence configuration.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `0.14.0` to `0.14.1`.