### PR TITLE
[0.21.0] Season configs and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - -->
 
+## [0.21.0] - 2025-06-20
+
+This updates provides two new commands for season configs and improvements to existing commands.
+
+### Added
+
+-   **New command!** `/season-bosses` - This command returns a display of the guild raid bosses in the previous 5 guild raid seasons.
+    -   Optional parameter: `Rarity` - filter by rarity.
+-   **New command!** `/season-same` - Displays the past seasons that has the same guild raid bosses as the provided season.
+    -   Required parameter: `season` - The number of the season you want to find a similar raid boss config for.
+
+### Changed
+
+-   Improved the readability and compactness of the `/gr-availability` command to use more emojis over text. Hopefully this makes the command more useful for mobile users.
+-   Tweaked pagination limits for `/gr-time-used` to display more data per page if primes are not displayed.
+-   Added caps to tokens used in a season and guild members in the average calculations for `/track-member`
+-   All displays of guild raid bosses with rarity and number (E3, L1 etc) are now zero-index-based -> the first one is L0 and the fifth legendary boss is L4.
+-   The label text for damage dealt in `/season-by-rarity` is changed from being the same as the graph title -> "Total damage"
+
 ## [0.20.0] - 2025-06-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "0.20.0",
+    "version": "0.21.0",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/commands/guild-raid/guildRaidAvailability.ts
+++ b/src/commands/guild-raid/guildRaidAvailability.ts
@@ -99,25 +99,45 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                 } else {
                     tokenIcon = "✅";
                 }
+                let nToken: string;
+                switch (available.tokens) {
+                    case 0:
+                        nToken = "0";
+                        break;
+                    case 1:
+                        nToken = "⅓";
+                        break;
+                    case 2:
+                        nToken = "⅔";
+                        break;
+                    default:
+                        nToken = "3⁄3";
+                        break;
+                }
 
                 if (!available.tokenCooldown)
-                    available.tokenCooldown = "NO COOLDOWN";
+                    available.tokenCooldown = "NONE..";
+                else {
+                    available.tokenCooldown = available.tokenCooldown
+                        .slice(0, -4)
+                        .replace(" ", "");
+                }
 
-                const tokenStatus = `${tokenIcon} \`${available.tokens}/3\` cooldown: \`${available.tokenCooldown}\``;
+                const tokenStatus = `${tokenIcon} ${nToken} \`${available.tokenCooldown}\``;
 
                 const bombIcon = available.bombs > 0 ? "✅" : `❌`;
 
                 let bombStatus: string;
                 if (!available.bombCooldown) {
-                    bombStatus = `${bombIcon} \`NOT USED YET\``;
+                    bombStatus = `${bombIcon} \`READY..\``;
                 } else {
                     bombStatus = `${bombIcon} \`${
                         available.bombs > 0 ? "+" : "-"
-                    }${available.bombCooldown}\``;
+                    }${available.bombCooldown.slice(0, -4).replace(" ", "")}\``;
                 }
 
                 return {
-                    text: `${tokenStatus} - Bomb: ${bombStatus} - **${userId}**`,
+                    text: `${tokenStatus} - ${bombStatus} - ${userId}`,
                     tokens: available.tokens,
                 };
             })
@@ -135,7 +155,12 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             .setColor("#0099ff")
             .setTitle("Available Tokens and Bombs")
             .setDescription(
-                "Here is the list of members with available tokens and bombs:\n Note that the token cooldowns have an inherit uncertainty due to the nature of the available data for the calculation. In certain cases the cooldown might not be accurate."
+                `Here is the list of members with available tokens and bombs.
+                
+                Note that the token cooldowns have an inherit uncertainty due to the nature of the available data for the calculation. 
+                In certain cases the cooldown might not be accurate.
+                
+                First values are tokens, second values are bombs, then usernames.`
             )
             .setTimestamp()
             .setFooter({

--- a/src/commands/guild-raid/guildRaidTimeUsed.ts
+++ b/src/commands/guild-raid/guildRaidTimeUsed.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/lib";
+import { MINIMUM_SEASON_THRESHOLD } from "@/lib/constants";
 import { DataTransformationService } from "@/lib/services/DataTransformationService";
 import { GuildService } from "@/lib/services/GuildService";
 import { splitByCapital } from "@/lib/utils";
@@ -18,7 +19,7 @@ export const data = new SlashCommandBuilder()
             .setName("season")
             .setDescription("The season number")
             .setRequired(true)
-            .setMinValue(70)
+            .setMinValue(MINIMUM_SEASON_THRESHOLD)
     )
     .addStringOption((option) => {
         return option

--- a/src/commands/guild-raid/guildRaidTimeUsed.ts
+++ b/src/commands/guild-raid/guildRaidTimeUsed.ts
@@ -86,7 +86,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
         );
 
         const pagination = new Pagination(interaction, {
-            limit: separatePrimes ? 5 : 10, // Adjust limit based on rarity
+            limit: separatePrimes ? 5 : 15, // Adjust limit based on rarity
         })
             .setColor("#0099ff")
             .setTitle(`Time Used Per Boss in season ${season}`)

--- a/src/commands/guild-raid/inactivityBySeason.ts
+++ b/src/commands/guild-raid/inactivityBySeason.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/lib";
+import { MINIMUM_SEASON_THRESHOLD } from "@/lib/constants";
 import { GuildService } from "@/lib/services/GuildService.ts";
 import { sortTokensUsed } from "@/lib/utils";
 import { Rarity } from "@/models/enums";
@@ -21,7 +22,7 @@ export const data = new SlashCommandBuilder()
             .setName("season")
             .setDescription("The season to check")
             .setRequired(true)
-            .setMinValue(70);
+            .setMinValue(MINIMUM_SEASON_THRESHOLD);
     })
     .addNumberOption((option) => {
         return option

--- a/src/commands/guild-raid/memberStatsBySeason.ts
+++ b/src/commands/guild-raid/memberStatsBySeason.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/lib";
+import { MINIMUM_SEASON_THRESHOLD } from "@/lib/constants";
 import { CsvService } from "@/lib/services/CsvService";
 import { GuildService } from "@/lib/services/GuildService.ts";
 import { Rarity } from "@/models/enums";
@@ -27,7 +28,7 @@ export const data = new SlashCommandBuilder()
             .setName("season")
             .setDescription("The season to check")
             .setRequired(true)
-            .setMinValue(70);
+            .setMinValue(MINIMUM_SEASON_THRESHOLD);
     })
     .addStringOption((option) => {
         return option

--- a/src/commands/guild-raid/metaTeamDistribution.ts
+++ b/src/commands/guild-raid/metaTeamDistribution.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/lib";
+import { MINIMUM_SEASON_THRESHOLD } from "@/lib/constants";
 import { ChartService } from "@/lib/services/ChartService";
 import { GuildService } from "@/lib/services/GuildService.ts";
 import { Rarity } from "@/models/enums";
@@ -18,7 +19,7 @@ export const data = new SlashCommandBuilder()
             .setName("season")
             .setDescription("The season number")
             .setRequired(true)
-            .setMinValue(70)
+            .setMinValue(MINIMUM_SEASON_THRESHOLD)
     )
     .addStringOption((option) => {
         return option

--- a/src/commands/guild-raid/seasonBombs.ts
+++ b/src/commands/guild-raid/seasonBombs.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/lib";
+import { MINIMUM_SEASON_THRESHOLD } from "@/lib/constants";
 import { ChartService } from "@/lib/services/ChartService";
 import { GuildService } from "@/lib/services/GuildService";
 import { numericAverage, numericMedian, standardDeviation } from "@/lib/utils";
@@ -18,7 +19,7 @@ export const data = new SlashCommandBuilder()
             .setName("season")
             .setDescription("The season number")
             .setRequired(true)
-            .setMinValue(70)
+            .setMinValue(MINIMUM_SEASON_THRESHOLD)
     )
     .addStringOption((option) =>
         option

--- a/src/commands/guild-raid/seasonBosses.ts
+++ b/src/commands/guild-raid/seasonBosses.ts
@@ -1,0 +1,92 @@
+import { logger } from "@/lib";
+import { GRConfigService } from "@/lib/services/GRConfigService";
+import { GuildService } from "@/lib/services/GuildService";
+import { getBossEmoji } from "@/lib/utils";
+import {
+    ChatInputCommandInteraction,
+    EmbedBuilder,
+    SlashCommandBuilder,
+} from "discord.js";
+
+export const cooldown = 5;
+
+export const data = new SlashCommandBuilder()
+    .setName("season-bosses")
+    .setDescription("Get the guild boss configs for the previous seasons");
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply({});
+
+    const discordId = interaction.user.id;
+
+    const guildService = new GuildService();
+
+    try {
+        const configs = await guildService.getNLastSeasonConfigs(discordId, 5);
+        if (configs === null || configs.length === 0) {
+            await interaction.editReply({
+                content:
+                    "Could not fetch data for you. Ensure your token is valid.",
+            });
+        }
+
+        const configService = GRConfigService.getInstance();
+
+        const embed = new EmbedBuilder()
+            .setColor("#0099ff")
+            .setTitle(`Guild Boss Configs for the last seasons`)
+            .setDescription(
+                `Here are the bosses for the last ${configs?.length} seasons.
+                
+                (Tervigon and Hive Tyrant use the same emoji because who cares about them anyway?)`
+            )
+            .setTimestamp();
+
+        const seasons = configs!.map((season) => {
+            const config = configService.getConfig(season.config);
+            if (!config) {
+                return;
+            }
+            return {
+                season: season.season,
+                config: config,
+            };
+        });
+
+        if (!seasons || seasons.length === 0) {
+            await interaction.editReply({
+                content: "No configs found for the specified rarity.",
+            });
+            return;
+        }
+
+        seasons.forEach((season) => {
+            if (season) {
+                const rarities = Object.keys(season.config);
+                const bosses = rarities
+                    .map((rarity) => {
+                        const bossList =
+                            season.config[rarity as keyof typeof season.config];
+                        if (bossList && bossList.length > 0) {
+                            return `**${rarity.at(0)}**: ${bossList
+                                .map((b) => getBossEmoji(b))
+                                .join("->")}`;
+                        }
+                        return `**${rarity}**: No bosses configured`;
+                    })
+                    .join("\n");
+                embed.addFields({
+                    name: `Season ${season.season}`,
+                    value: bosses,
+                });
+            }
+        });
+
+        await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+        logger.error(
+            error,
+            `Error while executing /season-configs command for ${interaction.user.username}`
+        );
+    }
+}

--- a/src/commands/guild-raid/seasonByRarity.ts
+++ b/src/commands/guild-raid/seasonByRarity.ts
@@ -125,7 +125,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                         sortGuildRaidResultDesc(data),
                         `Damage dealt in season ${season} - ${
                             rarity[0] ? rarity[0].toUpperCase() : " "
-                        }${(data[0] ? data[0].set : 0) + 1} ${bossName}`,
+                        }${data[0] ? data[0].set : 0} ${bossName}`,
                         averageMethod,
                         avgDamage
                     );

--- a/src/commands/guild-raid/seasonByRarity.ts
+++ b/src/commands/guild-raid/seasonByRarity.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/lib";
+import { MINIMUM_SEASON_THRESHOLD } from "@/lib/constants";
 import { ChartService } from "@/lib/services/ChartService";
 import { GuildService } from "@/lib/services/GuildService.ts";
 import {
@@ -23,7 +24,7 @@ export const data = new SlashCommandBuilder()
             .setName("season")
             .setDescription("The season number")
             .setRequired(true)
-            .setMinValue(70)
+            .setMinValue(MINIMUM_SEASON_THRESHOLD)
     )
     .addStringOption((option) => {
         return option

--- a/src/commands/guild-raid/seasonParticipation.ts
+++ b/src/commands/guild-raid/seasonParticipation.ts
@@ -13,6 +13,7 @@ import {
     sortGuildRaidResultDesc,
 } from "@/lib/utils";
 import { logger } from "@/lib";
+import { MINIMUM_SEASON_THRESHOLD } from "@/lib/constants";
 
 export const cooldown = 5;
 
@@ -23,7 +24,7 @@ export const data = new SlashCommandBuilder()
             .setName("season")
             .setDescription("The season number")
             .setRequired(true)
-            .setMinValue(70)
+            .setMinValue(MINIMUM_SEASON_THRESHOLD)
     )
     .addBooleanOption((option) =>
         option

--- a/src/commands/guild-raid/seasonSame.ts
+++ b/src/commands/guild-raid/seasonSame.ts
@@ -1,0 +1,71 @@
+import { logger } from "@/lib";
+import { GuildService } from "@/lib/services/GuildService";
+import {
+    ChatInputCommandInteraction,
+    EmbedBuilder,
+    SlashCommandBuilder,
+} from "discord.js";
+
+export const cooldown = 5;
+
+export const data = new SlashCommandBuilder()
+    .setName("season-same")
+    .setDescription("Get previous GR seasons with the same config")
+    .addNumberOption((option) =>
+        option
+            .setName("season")
+            .setDescription("The season number to check")
+            .setRequired(true)
+            .setMinValue(70)
+    );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply({});
+
+    const discordId = interaction.user.id;
+    const season = interaction.options.getNumber("season", true);
+
+    const guildService = new GuildService();
+
+    try {
+        const matches = await guildService.getSeasonsWithSameConfig(
+            discordId,
+            5,
+            season
+        );
+
+        if (!matches) {
+            await interaction.editReply({
+                content:
+                    "Could not fetch data for you. Ensure your token is valid.",
+            });
+            return;
+        }
+
+        if (matches.length === 0) {
+            await interaction.editReply({
+                content: `No previous seasons found with the same config as season ${season}.`,
+            });
+            return;
+        }
+
+        const embed = new EmbedBuilder()
+            .setColor("#0099ff")
+            .setTitle(`Guild raid seasons with the same config`)
+            .setTimestamp()
+            .setFields(
+                { name: "Your selected season", value: `${season}` },
+                {
+                    name: `Seasons`,
+                    value: matches.join(", "),
+                }
+            );
+
+        await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+        logger.error(
+            error,
+            `Error while executing /season-configs command for ${interaction.user.username}`
+        );
+    }
+}

--- a/src/commands/guild-raid/seasonSame.ts
+++ b/src/commands/guild-raid/seasonSame.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/lib";
+import { MINIMUM_SEASON_THRESHOLD } from "@/lib/constants";
 import { GuildService } from "@/lib/services/GuildService";
 import {
     ChatInputCommandInteraction,
@@ -16,7 +17,7 @@ export const data = new SlashCommandBuilder()
             .setName("season")
             .setDescription("The season number to check")
             .setRequired(true)
-            .setMinValue(70)
+            .setMinValue(MINIMUM_SEASON_THRESHOLD)
     );
 
 export async function execute(interaction: ChatInputCommandInteraction) {

--- a/src/commands/guild-raid/seasonTokens.ts
+++ b/src/commands/guild-raid/seasonTokens.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/lib";
+import { MINIMUM_SEASON_THRESHOLD } from "@/lib/constants";
 import { ChartService } from "@/lib/services/ChartService";
 import { GuildService } from "@/lib/services/GuildService.ts";
 import { numericAverage, numericMedian, standardDeviation } from "@/lib/utils";
@@ -22,7 +23,7 @@ export const data = new SlashCommandBuilder()
             .setName("season")
             .setDescription("The season to check")
             .setRequired(true)
-            .setMinValue(70);
+            .setMinValue(MINIMUM_SEASON_THRESHOLD);
     })
     .addStringOption((option) => {
         return option

--- a/src/commands/guild-raid/seasons.ts
+++ b/src/commands/guild-raid/seasons.ts
@@ -22,44 +22,40 @@ export async function execute(interaction: ChatInputCommandInteraction) {
     try {
         const result = await service.getGuildSeasons(interaction.user.id);
 
-        if (result == null) {
+        if (!result) {
             await interaction.editReply({
                 content:
                     "Could not fetch guild seasons. Ensure you are registered and have the correct permissions",
             });
-        } else if (result.length === 0) {
-            await interaction.editReply({
-                content: "No seasons available for your guild",
-            });
-        } else {
-            const embed = new EmbedBuilder()
-                .setColor("#0099ff")
-                .setTitle("Available Guild Raid Seasons")
-                .setDescription(
-                    `Fetches the seasons your guild has available data for. The public API does not include data pre season 70.`
-                )
-                .addFields([
-                    {
-                        name: "Current season",
-                        value:
-                            result[result.length - 1]?.toString() ??
-                            "Something went wrong...",
-                        inline: true,
-                    },
-                    {
-                        name: "Seasons",
-                        value: result.join(", "),
-                        inline: false,
-                    },
-                ])
-                .setFooter({
-                    text: "Note: Snowprint may not return all seasons due to a known API bug.",
-                });
-
-            await interaction.editReply({
-                embeds: [embed],
-            });
+            return;
         }
+
+        const embed = new EmbedBuilder()
+            .setColor("#0099ff")
+            .setTitle("Available Guild Raid Seasons")
+            .setDescription(
+                `Fetches the seasons your guild has available data for. The public API does not include data pre season 70.`
+            )
+            .addFields([
+                {
+                    name: "Current season",
+                    value:
+                        result.at(-1)?.toString() ?? "Something went wrong...",
+                    inline: true,
+                },
+                {
+                    name: "Seasons",
+                    value: result.join(", "),
+                    inline: false,
+                },
+            ])
+            .setFooter({
+                text: "Note: Snowprint may not return all seasons due to a known API bug.",
+            });
+
+        await interaction.editReply({
+            embeds: [embed],
+        });
 
         logger.info(`${interaction.user.username} used /seasons`);
     } catch (error) {

--- a/src/commands/guild-raid/trackMember.ts
+++ b/src/commands/guild-raid/trackMember.ts
@@ -106,6 +106,13 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             .setColor("#0099ff")
             .setTimestamp();
 
+        if (rarity) {
+            embed.addFields({
+                name: `Rarity: ${rarity}`,
+                value: "Rarity filter applied and the damage a user did to a boss relative to the avg total damage dealt by the guild will be displayed",
+            });
+        }
+
         for (const [season, stats] of Object.entries(data)) {
             if (!stats) {
                 continue;

--- a/src/commands/guild-raid/trackMember.ts
+++ b/src/commands/guild-raid/trackMember.ts
@@ -127,7 +127,11 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
             const guildAverageDamage = allDamage / nMembers;
 
-            const guildAverageTokens = allTokens / nMembers;
+            let guildAverageTokens = allTokens / nMembers;
+
+            if (guildAverageTokens > 29) {
+                guildAverageTokens = 29;
+            }
 
             const userData = Object.values(vals).filter(
                 (season) => season?.username === memberId

--- a/src/commands/guild-raid/trackMember.ts
+++ b/src/commands/guild-raid/trackMember.ts
@@ -193,15 +193,17 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
                     const userDamage = userData.totalDamage || 0;
                     const userTokens = userData.totalTokens || 0;
-                    const userAvg =
-                        userTokens > 0
-                            ? (userDamage / userTokens).toLocaleString(
-                                  undefined,
-                                  {
-                                      maximumFractionDigits: 1,
-                                  }
-                              )
-                            : "0";
+
+                    if (userTokens === 0) {
+                        continue;
+                    }
+
+                    const userAvg = (userDamage / userTokens).toLocaleString(
+                        undefined,
+                        {
+                            maximumFractionDigits: 1,
+                        }
+                    );
 
                     const relativeDamage =
                         ((userDamage / avgDamage) * 100).toLocaleString(
@@ -211,19 +213,20 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                             }
                         ) + "%";
 
-                    userStatsPerBoss[boss] = [userAvg, relativeDamage];
+                    const bossName =
+                        rarity[0]! +
+                        userData.set +
+                        " " +
+                        boss.split(/(?=[A-Z])/)[0]?.substring(0, 4);
+
+                    userStatsPerBoss[bossName] = [userAvg, relativeDamage];
                 }
 
                 const bossRelativeStrings = Object.entries(userStatsPerBoss)
-                    .map(([boss, user], idx) => {
-                        const bossName =
-                            rarity[0]! +
-                            (idx + 1) +
-                            " " +
-                            boss.split(/(?=[A-Z])/)[0]?.substring(0, 4);
+                    .map(([bossname, user]) => {
                         const userAvgStr = user[0];
                         const userRelativeTotal = user[1];
-                        return `${bossName.padEnd(8)} ${userAvgStr!.padStart(
+                        return `${bossname.padEnd(8)} ${userAvgStr!.padStart(
                             10
                         )} ${userRelativeTotal!.padStart(8)}`;
                     })

--- a/src/commands/guild-raid/trackMember.ts
+++ b/src/commands/guild-raid/trackMember.ts
@@ -1,4 +1,8 @@
 import { logger } from "@/lib";
+import {
+    MAXIMUM_GUILD_MEMBERS,
+    MAXIMUM_TOKENS_PER_SEASON,
+} from "@/lib/constants";
 import { GuildService } from "@/lib/services/GuildService";
 import { Rarity } from "@/models/enums";
 import {
@@ -121,16 +125,16 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             let nMembers = new Set<string>(vals.map((entry) => entry?.username))
                 .size;
 
-            if (nMembers > 30) {
-                nMembers = 30;
+            if (nMembers > MAXIMUM_GUILD_MEMBERS) {
+                nMembers = MAXIMUM_GUILD_MEMBERS;
             }
 
             const guildAverageDamage = allDamage / nMembers;
 
             let guildAverageTokens = allTokens / nMembers;
 
-            if (guildAverageTokens > 29) {
-                guildAverageTokens = 29;
+            if (guildAverageTokens > MAXIMUM_TOKENS_PER_SEASON) {
+                guildAverageTokens = MAXIMUM_TOKENS_PER_SEASON;
             }
 
             const userData = Object.values(vals).filter(
@@ -185,8 +189,8 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                         values.map((v) => v.username)
                     ).size;
 
-                    if (nPlayers > 30) {
-                        nPlayers = 30;
+                    if (nPlayers > MAXIMUM_GUILD_MEMBERS) {
+                        nPlayers = MAXIMUM_GUILD_MEMBERS;
                     }
 
                     const totalDamage = values

--- a/src/lib/configs/GuildBossSeasonConfigs.json
+++ b/src/lib/configs/GuildBossSeasonConfigs.json
@@ -1,0 +1,172 @@
+{
+    "guild_boss_season_config_1": {
+        "common": [
+            "C0 Tervigon (Leviathan)",
+            "C1 Hive Tyrant (Leviathan)",
+            "C2 Tervigon (Gorgon)",
+            "C3 Screamer-Killer"
+        ],
+        "uncommon": [
+            "U0 Hive Tyrant (Kronos)",
+            "U1 Tervigon (Leviathan)",
+            "U2 Hive Tyrant (Gorgon)",
+            "U3 Belisarius"
+        ],
+        "rare": [
+            "R0 Tervigon (Kronos)",
+            "R1 Screamer-Killer",
+            "R2 Avatar Of Khaine",
+            "R3 Ghazghkull"
+        ],
+        "epic": [
+            "E0 Hive Tyrant (Leviathan)",
+            "E1 Tervigon (Leviathan)",
+            "E2 Screamer-Killer",
+            "E3 Belisarius",
+            "E4 Mortarion"
+        ],
+        "legendary": [
+            "L0 Ghazghkull",
+            "L1 Avatar Of Khaine",
+            "L2 Magnus",
+            "L3 Silent King",
+            "L4 Mortarion"
+        ]
+    },
+    "guild_boss_season_config_2": {
+        "common": [
+            "C0 Tervigon ((Leviathan))",
+            "C1 Hive Tyrant (Leviathan)",
+            "C2 Hive Tyrant (Gorgon)",
+            "C3 Screamer-Killer"
+        ],
+        "uncommon": [
+            "U0 Tervigon (Kronos)",
+            "U1 Hive Tyrant (Leviathan)",
+            "U2 Tervigon (Gorgon)",
+            "U3 Screamer-Killer"
+        ],
+        "rare": [
+            "R0 Tervigon (Leviathan)",
+            "R1 Hive Tyrant (Kronos)",
+            "R2 Rogal Dorn",
+            "R3 Belisarius"
+        ],
+        "epic": [
+            "E0 Screamer-Killer",
+            "E1 Hive Tyrant (Gorgon)",
+            "E2 Ghazghkull",
+            "E3 Avatar Of Khaine",
+            "E4 Belisarius"
+        ],
+        "legendary": [
+            "L0 Rogal Dorn",
+            "L1 Screamer-Killer",
+            "L2 Avatar Of Khaine",
+            "L3 Ghazghkull",
+            "L4 Belisarius"
+        ]
+    },
+    "guild_boss_season_config_3": {
+        "common": [
+            "C0 Tervigon (Leviathan)",
+            "C1 Hive Tyrant (Leviathan)",
+            "C2 Tervigon (Gorgon)",
+            "C3 Screamer-Killer"
+        ],
+        "uncommon": [
+            "U0 Hive Tyrant (Kronos)",
+            "U1 Tervigon (Leviathan)",
+            "U2 Hive Tyrant (Gorgon)",
+            "U3 Ghazghkull"
+        ],
+        "rare": [
+            "R0 Screamer-Killer",
+            "R1 Belisarius",
+            "R2 Ghazghkull",
+            "R3 Avatar Of Khaine"
+        ],
+        "epic": [
+            "E0 Rogal Dorn",
+            "E1 Belisarius",
+            "E2 Avatar Of Khaine",
+            "E3 Ghazghkull",
+            "E4 Silent King"
+        ],
+        "legendary": [
+            "L0 Belisarius",
+            "L1 Ghazghkull",
+            "L2 Mortarion",
+            "L3 Magnus",
+            "L4 Silent King"
+        ]
+    },
+    "guild_boss_season_config_4": {
+        "common": [
+            "C0 Tervigon (Leviathan)",
+            "C1 Hive Tyrant (Leviathan)",
+            "C2 Hive Tyrant (Gorgon)",
+            "C3 Screamer-Killer"
+        ],
+        "uncommon": [
+            "U0 Tervigon (Kronos)",
+            "U1 Hive Tyrant (Leviathan)",
+            "U2 Tervigon (Gorgon)",
+            "U3 Screamer-Killer"
+        ],
+        "rare": [
+            "R0 Rogal Dorn",
+            "R1 Avatar Of Khaine",
+            "R2 Belisarius",
+            "R3 Ghazghkull"
+        ],
+        "epic": [
+            "E0 Tervigon (Leviathan)",
+            "E1 Screamer-Killer",
+            "E2 Rogal Dorn",
+            "E3 Belisarius",
+            "E4 Magnus"
+        ],
+        "legendary": [
+            "L0 Ghazghkull",
+            "L1 Avatar Of Khaine",
+            "L2 Silent King",
+            "L3 Mortarion",
+            "L4 Magnus"
+        ]
+    },
+    "guild_boss_season_config_5": {
+        "common": [
+            "C0 Tervigon (Leviathan)",
+            "C1 Hive Tyrant (Leviathan)",
+            "C2 Tervigon (Gorgon)",
+            "C3 Screamer-Killer"
+        ],
+        "uncommon": [
+            "U0 Hive Tyrant (Kronos)",
+            "U1 Tervigon (Leviathan)",
+            "U2 Hive Tyrant (Gorgon)",
+            "U3 Avatar Of Khaine"
+        ],
+        "rare": [
+            "R0 Screamer-Killer",
+            "R1 Rogal Dorn",
+            "R2 Avatar Of Khaine",
+            "R3 Belisarius"
+        ],
+        "epic": [
+            "E0 Screamer-Killer",
+            "E1 Rogal Dorn",
+            "E2 Belisarius",
+            "E3 Avatar Of Khaine",
+            "E4 Ghazghkull"
+        ],
+        "legendary": [
+            "L0 Screamer-Killer",
+            "L1 Hive Tyrant (Gorgon)",
+            "L2 Rogal Dorn",
+            "L3 Belisarius",
+            "L4 Avatar Of Khaine"
+        ]
+    }
+}

--- a/src/lib/configs/GuildBossSeasonConfigs.json
+++ b/src/lib/configs/GuildBossSeasonConfigs.json
@@ -1,65 +1,65 @@
 {
     "guild_boss_season_config_1": {
-        "common": [
+        "Common": [
             "C0 Tervigon (Leviathan)",
             "C1 Hive Tyrant (Leviathan)",
             "C2 Tervigon (Gorgon)",
             "C3 Screamer-Killer"
         ],
-        "uncommon": [
+        "Uncommon": [
             "U0 Hive Tyrant (Kronos)",
             "U1 Tervigon (Leviathan)",
             "U2 Hive Tyrant (Gorgon)",
             "U3 Belisarius"
         ],
-        "rare": [
+        "Rare": [
             "R0 Tervigon (Kronos)",
             "R1 Screamer-Killer",
             "R2 Avatar Of Khaine",
             "R3 Ghazghkull"
         ],
-        "epic": [
+        "Epic": [
             "E0 Hive Tyrant (Leviathan)",
             "E1 Tervigon (Leviathan)",
             "E2 Screamer-Killer",
             "E3 Belisarius",
             "E4 Mortarion"
         ],
-        "legendary": [
+        "Legendary": [
             "L0 Ghazghkull",
             "L1 Avatar Of Khaine",
             "L2 Magnus",
-            "L3 Silent King",
+            "L3 Szarekh",
             "L4 Mortarion"
         ]
     },
     "guild_boss_season_config_2": {
-        "common": [
+        "Common": [
             "C0 Tervigon ((Leviathan))",
             "C1 Hive Tyrant (Leviathan)",
             "C2 Hive Tyrant (Gorgon)",
             "C3 Screamer-Killer"
         ],
-        "uncommon": [
+        "Uncommon": [
             "U0 Tervigon (Kronos)",
             "U1 Hive Tyrant (Leviathan)",
             "U2 Tervigon (Gorgon)",
             "U3 Screamer-Killer"
         ],
-        "rare": [
+        "Rare": [
             "R0 Tervigon (Leviathan)",
             "R1 Hive Tyrant (Kronos)",
             "R2 Rogal Dorn",
             "R3 Belisarius"
         ],
-        "epic": [
+        "Epic": [
             "E0 Screamer-Killer",
             "E1 Hive Tyrant (Gorgon)",
             "E2 Ghazghkull",
             "E3 Avatar Of Khaine",
             "E4 Belisarius"
         ],
-        "legendary": [
+        "Legendary": [
             "L0 Rogal Dorn",
             "L1 Screamer-Killer",
             "L2 Avatar Of Khaine",
@@ -68,100 +68,100 @@
         ]
     },
     "guild_boss_season_config_3": {
-        "common": [
+        "Common": [
             "C0 Tervigon (Leviathan)",
             "C1 Hive Tyrant (Leviathan)",
             "C2 Tervigon (Gorgon)",
             "C3 Screamer-Killer"
         ],
-        "uncommon": [
+        "Uncommon": [
             "U0 Hive Tyrant (Kronos)",
             "U1 Tervigon (Leviathan)",
             "U2 Hive Tyrant (Gorgon)",
             "U3 Ghazghkull"
         ],
-        "rare": [
+        "Rare": [
             "R0 Screamer-Killer",
             "R1 Belisarius",
             "R2 Ghazghkull",
             "R3 Avatar Of Khaine"
         ],
-        "epic": [
+        "Epic": [
             "E0 Rogal Dorn",
             "E1 Belisarius",
             "E2 Avatar Of Khaine",
             "E3 Ghazghkull",
-            "E4 Silent King"
+            "E4 Szarekh"
         ],
-        "legendary": [
+        "Legendary": [
             "L0 Belisarius",
             "L1 Ghazghkull",
             "L2 Mortarion",
             "L3 Magnus",
-            "L4 Silent King"
+            "L4 Szarekh"
         ]
     },
     "guild_boss_season_config_4": {
-        "common": [
+        "Common": [
             "C0 Tervigon (Leviathan)",
             "C1 Hive Tyrant (Leviathan)",
             "C2 Hive Tyrant (Gorgon)",
             "C3 Screamer-Killer"
         ],
-        "uncommon": [
+        "Uncommon": [
             "U0 Tervigon (Kronos)",
             "U1 Hive Tyrant (Leviathan)",
             "U2 Tervigon (Gorgon)",
             "U3 Screamer-Killer"
         ],
-        "rare": [
+        "Rare": [
             "R0 Rogal Dorn",
             "R1 Avatar Of Khaine",
             "R2 Belisarius",
             "R3 Ghazghkull"
         ],
-        "epic": [
+        "Epic": [
             "E0 Tervigon (Leviathan)",
             "E1 Screamer-Killer",
             "E2 Rogal Dorn",
             "E3 Belisarius",
             "E4 Magnus"
         ],
-        "legendary": [
+        "Legendary": [
             "L0 Ghazghkull",
             "L1 Avatar Of Khaine",
-            "L2 Silent King",
+            "L2 Szarekh",
             "L3 Mortarion",
             "L4 Magnus"
         ]
     },
     "guild_boss_season_config_5": {
-        "common": [
+        "Common": [
             "C0 Tervigon (Leviathan)",
             "C1 Hive Tyrant (Leviathan)",
             "C2 Tervigon (Gorgon)",
             "C3 Screamer-Killer"
         ],
-        "uncommon": [
+        "Uncommon": [
             "U0 Hive Tyrant (Kronos)",
             "U1 Tervigon (Leviathan)",
             "U2 Hive Tyrant (Gorgon)",
             "U3 Avatar Of Khaine"
         ],
-        "rare": [
+        "Rare": [
             "R0 Screamer-Killer",
             "R1 Rogal Dorn",
             "R2 Avatar Of Khaine",
             "R3 Belisarius"
         ],
-        "epic": [
+        "Epic": [
             "E0 Screamer-Killer",
             "E1 Rogal Dorn",
             "E2 Belisarius",
             "E3 Avatar Of Khaine",
             "E4 Ghazghkull"
         ],
-        "legendary": [
+        "Legendary": [
             "L0 Screamer-Killer",
             "L1 Hive Tyrant (Gorgon)",
             "L2 Rogal Dorn",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,3 @@
+export const MINIMUM_SEASON_THRESHOLD = 70;
+export const MAXIMUM_GUILD_MEMBERS = 30;
+export const MAXIMUM_TOKENS_PER_SEASON = 29;

--- a/src/lib/services/ChartService.ts
+++ b/src/lib/services/ChartService.ts
@@ -218,7 +218,7 @@ export class ChartService {
                     },
                     {
                         backgroundColor: CHART_COLORS.blue,
-                        label: title,
+                        label: "Total damage",
                         data: damage,
                         borderWidth: 1,
                     },

--- a/src/lib/services/GRConfigService.ts
+++ b/src/lib/services/GRConfigService.ts
@@ -1,0 +1,38 @@
+import type { GrBossConfig } from "@/models/types";
+import * as fs from "fs";
+
+export class GRConfigService {
+    private static instance: GRConfigService;
+    private base = "guild_boss_season_config_";
+
+    private config: Record<string, GrBossConfig> = {};
+
+    private constructor() {
+        // Load and parse the JSON config here
+        const raw = fs.readFileSync(
+            require.resolve("../configs/GuildBossSeasonConfigs.json"),
+            "utf-8"
+        );
+
+        this.config = JSON.parse(raw);
+    }
+
+    public static getInstance(): GRConfigService {
+        if (!GRConfigService.instance) {
+            GRConfigService.instance = new GRConfigService();
+        }
+        return GRConfigService.instance;
+    }
+
+    public getConfigs() {
+        return this.config;
+    }
+
+    public getConfig(n: number) {
+        if (n < 1 || n > 5) {
+            throw new Error("Invalid season number. Must be between 1 and 5.");
+        }
+        const key = `${this.base}${n}`;
+        return this.config[key];
+    }
+}

--- a/src/lib/services/GuildService.ts
+++ b/src/lib/services/GuildService.ts
@@ -18,6 +18,7 @@ import {
     testApiToken,
 } from "../utils";
 import type { GuildMemberMapping } from "@/models/types/GuildMemberMapping";
+import { MINIMUM_SEASON_THRESHOLD } from "../constants";
 
 /**
  * Service class for managing guild-related operations in the Homina Tacticus application.
@@ -1236,7 +1237,7 @@ export class GuildService {
             const currentSeasonNumber = currentSeason.season;
             const seasons: number[] = [];
             for (let i = nSeasons; i > 0; i--) {
-                if (currentSeasonNumber - i < 70) {
+                if (currentSeasonNumber - i < MINIMUM_SEASON_THRESHOLD) {
                     break;
                 }
                 seasons.push(currentSeasonNumber - i);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -321,3 +321,45 @@ export function standardDeviation(arr: number[]): number {
     const variance = numericAverage(squaredDiffs);
     return Math.sqrt(variance);
 }
+
+export function getBossEmoji(boss: string) {
+    // Remove first two chracters
+    const bossname = boss.slice(2).trim().replace(/[()]/g, "");
+    const words = splitByCapital(bossname);
+    const identifier = words.at(0);
+    if (!identifier) {
+        return "❓"; // Fallback emoji if no identifier is found
+    }
+
+    if (identifier === "Szarekh") {
+        return "<:Szarekh:1385343132950069278>";
+    } else if (identifier === "Tervigon") {
+        const version = words.at(1);
+        if (version === "Leviathan")
+            return "<:TyrantLeviathan:1385342042170851334>";
+        if (version === "Gorgon") return "<:TyrantGorgon:1385340907351441619>";
+        if (version === "Kronos") return "<:TyrantKronos:1385341128626409522>";
+    } else if (identifier === "Hive") {
+        const version = words.at(2);
+        if (version === "Leviathan")
+            return "<:TyrantLeviathan:1385342042170851334>";
+        if (version === "Gorgon") return "<:TyrantGorgon:1385340907351441619>";
+        if (version === "Kronos") return "<:TyrantKronos:1385341128626409522>";
+    } else if (identifier === "Ghazghkull") {
+        return "<:Ghazghkull:1385340195494170664>";
+    } else if (identifier === "Avatar") {
+        return "<:Avatar:1385338950834716802>";
+    } else if (identifier === "Magnus") {
+        return "<:Magnus:1385342412217520379>";
+    } else if (identifier === "Mortarion") {
+        return "<:Mortarion:1385342557969453197>";
+    } else if (identifier === "Belisarius") {
+        return "<:Cawl:1385339595578806312>";
+    } else if (identifier === "Rogal") {
+        return "<:RogalDornTank:1385342727037784174>";
+    } else if (identifier === "Screamer-") {
+        return "<:ScreamerKiller:1385342920302788608>";
+    } else {
+        return "❓"; // Fallback emoji if no specific emoji is found
+    }
+}

--- a/src/models/types/SeasonConfig.ts
+++ b/src/models/types/SeasonConfig.ts
@@ -1,7 +1,7 @@
 export interface GrBossConfig {
-    common: string[];
-    uncommon: string[];
-    rare: string[];
-    epic: string[];
-    legendary: string[];
+    Common: string[];
+    Uncommon: string[];
+    Rare: string[];
+    Epic: string[];
+    Legendary: string[];
 }

--- a/src/models/types/SeasonConfig.ts
+++ b/src/models/types/SeasonConfig.ts
@@ -1,0 +1,7 @@
+export interface GrBossConfig {
+    common: string[];
+    uncommon: string[];
+    rare: string[];
+    epic: string[];
+    legendary: string[];
+}

--- a/src/models/types/index.ts
+++ b/src/models/types/index.ts
@@ -12,3 +12,4 @@ export * from "./PlayerDetails";
 export * from "./Player";
 export * from "./UnitItem";
 export * from "./TokenStatus";
+export * from "./SeasonConfig";

--- a/src/test/services/GRConfigServiceSuite.test.ts
+++ b/src/test/services/GRConfigServiceSuite.test.ts
@@ -1,0 +1,47 @@
+import { GRConfigService } from "@/lib/services/GRConfigService";
+import { describe, expect, test } from "bun:test";
+
+const configService = GRConfigService.getInstance();
+
+describe("GRConfigServiceSuite", () => {
+    test("should return the same instance (singleton)", () => {
+        const instance1 = GRConfigService.getInstance();
+        const instance2 = GRConfigService.getInstance();
+        expect(instance1).toBe(instance2);
+    });
+
+    test("should load config with expected keys", () => {
+        const config = configService.getConfigs();
+        expect(config).toBeDefined();
+        expect(typeof config).toBe("object");
+        expect(config).toHaveProperty("guild_boss_season_config_1");
+    });
+
+    test("should have all required properties in a config", () => {
+        const config = configService.getConfigs();
+        const config1 = config["guild_boss_season_config_1"];
+        expect(config1).toHaveProperty("common");
+        expect(config1).toHaveProperty("uncommon");
+        expect(config1).toHaveProperty("rare");
+        expect(config1).toHaveProperty("epic");
+        expect(config1).toHaveProperty("legendary");
+    });
+
+    test("should contain the correct values for the rarity levels", () => {
+        const config = configService.getConfig(1);
+        expect(config).toBeDefined();
+        expect(config).toHaveProperty("common");
+        expect(config).toHaveProperty("uncommon");
+        expect(config).toHaveProperty("rare");
+        expect(config).toHaveProperty("epic");
+        expect(config).toHaveProperty("legendary");
+        expect(config!.common.length).toEqual(4);
+        expect(config!.uncommon.length).toEqual(4);
+        expect(config!.rare.length).toEqual(4);
+        expect(config!.epic.length).toEqual(5);
+        expect(config!.legendary.length).toEqual(5);
+        expect(config!.common[0]).toBe("C0 Tervigon (Leviathan)");
+        expect(config!.uncommon[0]).toBe("U0 Hive Tyrant (Kronos)");
+        expect(config!.legendary[3]).toBe("L3 Silent King");
+    });
+});

--- a/src/test/services/GRConfigServiceSuite.test.ts
+++ b/src/test/services/GRConfigServiceSuite.test.ts
@@ -20,28 +20,28 @@ describe("GRConfigServiceSuite", () => {
     test("should have all required properties in a config", () => {
         const config = configService.getConfigs();
         const config1 = config["guild_boss_season_config_1"];
-        expect(config1).toHaveProperty("common");
-        expect(config1).toHaveProperty("uncommon");
-        expect(config1).toHaveProperty("rare");
-        expect(config1).toHaveProperty("epic");
-        expect(config1).toHaveProperty("legendary");
+        expect(config1).toHaveProperty("Common");
+        expect(config1).toHaveProperty("Uncommon");
+        expect(config1).toHaveProperty("Rare");
+        expect(config1).toHaveProperty("Epic");
+        expect(config1).toHaveProperty("Legendary");
     });
 
     test("should contain the correct values for the rarity levels", () => {
         const config = configService.getConfig(1);
         expect(config).toBeDefined();
-        expect(config).toHaveProperty("common");
-        expect(config).toHaveProperty("uncommon");
-        expect(config).toHaveProperty("rare");
-        expect(config).toHaveProperty("epic");
-        expect(config).toHaveProperty("legendary");
-        expect(config!.common.length).toEqual(4);
-        expect(config!.uncommon.length).toEqual(4);
-        expect(config!.rare.length).toEqual(4);
-        expect(config!.epic.length).toEqual(5);
-        expect(config!.legendary.length).toEqual(5);
-        expect(config!.common[0]).toBe("C0 Tervigon (Leviathan)");
-        expect(config!.uncommon[0]).toBe("U0 Hive Tyrant (Kronos)");
-        expect(config!.legendary[3]).toBe("L3 Silent King");
+        expect(config).toHaveProperty("Common");
+        expect(config).toHaveProperty("Uncommon");
+        expect(config).toHaveProperty("Rare");
+        expect(config).toHaveProperty("Epic");
+        expect(config).toHaveProperty("Legendary");
+        expect(config!.Common.length).toEqual(4);
+        expect(config!.Uncommon.length).toEqual(4);
+        expect(config!.Rare.length).toEqual(4);
+        expect(config!.Epic.length).toEqual(5);
+        expect(config!.Legendary.length).toEqual(5);
+        expect(config!.Common[0]).toBe("C0 Tervigon (Leviathan)");
+        expect(config!.Uncommon[0]).toBe("U0 Hive Tyrant (Kronos)");
+        expect(config!.Legendary[3]).toBe("L3 Szarekh");
     });
 });

--- a/src/test/utilsSuite.test.ts
+++ b/src/test/utilsSuite.test.ts
@@ -16,6 +16,7 @@ import {
     numericMedian,
     isValidUUIDv4,
     splitByCapital,
+    getBossEmoji,
 } from "@/lib/utils";
 import type { GuildRaidResult } from "@/models/types";
 import { describe, expect, test } from "bun:test";
@@ -272,5 +273,58 @@ describe("utilsSuite - Algebra", () => {
         const camelCaseString = "lowerCamelCase";
         const result = splitByCapital(camelCaseString);
         expect(result).toEqual(["lower", "Camel", "Case"]);
+    });
+
+    test("splitByCapital - should handle dashes and underscores appropriately", () => {
+        const boss = "Screamer-Killer";
+        const result = splitByCapital(boss);
+        expect(result).toEqual(["Screamer-", "Killer"]);
+    });
+
+    test("getBossEmoji - Should return correct emoji for known bosses", () => {
+        expect(getBossEmoji("xxSzarekh")).toBe(
+            "<:Szarekh:1385343132950069278>"
+        );
+        expect(getBossEmoji("xxTervigon (Leviathan)")).toBe(
+            "<:TyrantLeviathan:1385342042170851334>"
+        );
+        expect(getBossEmoji("xxTervigon (Gorgon)")).toBe(
+            "<:TyrantGorgon:1385340907351441619>"
+        );
+        expect(getBossEmoji("xxTervigon (Kronos)")).toBe(
+            "<:TyrantKronos:1385341128626409522>"
+        );
+        expect(getBossEmoji("xxHive Tyrant (Leviathan)")).toBe(
+            "<:TyrantLeviathan:1385342042170851334>"
+        );
+        expect(getBossEmoji("xxHive Tyrant (Gorgon)")).toBe(
+            "<:TyrantGorgon:1385340907351441619>"
+        );
+        expect(getBossEmoji("xxHive Tyrant (Kronos)")).toBe(
+            "<:TyrantKronos:1385341128626409522>"
+        );
+        expect(getBossEmoji("xxGhazghkull")).toBe(
+            "<:Ghazghkull:1385340195494170664>"
+        );
+        expect(getBossEmoji("xxAvatar")).toBe("<:Avatar:1385338950834716802>");
+        expect(getBossEmoji("xxMagnus")).toBe("<:Magnus:1385342412217520379>");
+        expect(getBossEmoji("xxMortarion")).toBe(
+            "<:Mortarion:1385342557969453197>"
+        );
+        expect(getBossEmoji("xxBelisarius")).toBe(
+            "<:Cawl:1385339595578806312>"
+        );
+        expect(getBossEmoji("xxRogal")).toBe(
+            "<:RogalDornTank:1385342727037784174>"
+        );
+        expect(getBossEmoji("xxScreamer-Killer")).toBe(
+            "<:ScreamerKiller:1385342920302788608>"
+        );
+    });
+
+    test("getBossEmoji - Should return fallback emoji for unknown or malformed input", () => {
+        expect(getBossEmoji("")).toBe("❓");
+        expect(getBossEmoji("xxUnknownBoss")).toBe("❓");
+        expect(getBossEmoji("x")).toBe("❓");
     });
 });


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the guild raid command functionalities, including new commands, improved user feedback, and updated configurations. The most notable changes include the addition of two new commands (`/season-bosses` and `/season-same`), updates to token and bomb status formatting, and the introduction of a configuration service for guild boss seasons.

### New Features:
* **New `/season-bosses` Command**: Added a command to retrieve guild boss configurations for the last five seasons, including detailed rarity and boss information. (`src/commands/guild-raid/seasonBosses.ts`)
* **New `/season-same` Command**: Added a command to find previous seasons with the same configuration as a specified season, with support for user input validation. (`src/commands/guild-raid/seasonSame.ts`)

### Enhancements to Existing Commands:
* **Improved Token and Bomb Status Display**: Updated the formatting of token and bomb statuses, including fractional token representations and refined cooldown text. (`src/commands/guild-raid/guildRaidAvailability.ts`)
* **Pagination Limit Adjustment**: Increased the pagination limit for the `/guild-raid-time-used` command to accommodate larger data sets. (`src/commands/guild-raid/guildRaidTimeUsed.ts`)
* **Refinements to `/seasons` Command**: Simplified condition handling and improved the display of the current season using modern JavaScript methods. (`src/commands/guild-raid/seasons.ts`) [[1]](diffhunk://#diff-9751e9c215e5a9ec900b2198ef9c5ff4d3803c056efec311f3d3817b3250d31fL25-R32) [[2]](diffhunk://#diff-9751e9c215e5a9ec900b2198ef9c5ff4d3803c056efec311f3d3817b3250d31fL45-R43) [[3]](diffhunk://#diff-9751e9c215e5a9ec900b2198ef9c5ff4d3803c056efec311f3d3817b3250d31fL62)

### Configuration and Data Updates:
* **Guild Boss Season Configurations**: Introduced a JSON file containing detailed configurations for guild bosses across multiple seasons. (`src/lib/configs/GuildBossSeasonConfigs.json`)
* **Configuration Service**: Added `GRConfigService` to manage and retrieve guild boss season configurations programmatically. (`src/lib/services/GRConfigService.ts`)

### Miscellaneous Fixes:
* **Guild Service Season Filtering**: Added a check to ensure season numbers do not fall below a minimum threshold when fetching past seasons. (`src/lib/services/GuildService.ts`)
* **Capping Average Tokens**: Implemented a cap for average tokens in the `/track-member` command to prevent unrealistic values. (`src/commands/guild-raid/trackMember.ts`)
* **Chart Label Update**: Changed the chart label in `ChartService` to "Total damage" for better clarity. (`src/lib/services/ChartService.ts`)