### PR TITLE
[0.21.1] Guild members count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - -->
 
+## [0.21.1] - 2025-06-22
+
+Tiny patch this weekend as I've been a bit busy hosting guests of my partner. Going to be moving next week, but I'll try to get at least one update out with some more functionality.
+
+### Changed
+
+-   `/bot-stats` now also shows the count of guild-member-mappings to display the number of members that are being processed by the bot.
+
 ## [0.21.0] - 2025-06-20
 
 This updates provides two new commands for season configs and improvements to existing commands.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "0.21.0",
+    "version": "0.21.1",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/commands/utility/stats.ts
+++ b/src/commands/utility/stats.ts
@@ -23,6 +23,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
         const formattedUptime = SecondsToString(uptime);
         const guildCount = client.guilds.cache.size;
         const registeredUser = await dbController.getNumberOfUsers();
+        const registeredMembers = await dbController.getMemberCount();
 
         const statsEmbed = new EmbedBuilder()
             .setColor(0x0099ff)
@@ -33,12 +34,17 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                 {
                     name: "Server count",
                     value: guildCount.toString(),
-                    inline: true,
+                    inline: false,
                 },
                 {
                     name: "User Count",
                     value: registeredUser.toString(),
-                    inline: true,
+                    inline: false,
+                },
+                {
+                    name: "Guild-members Count",
+                    value: registeredMembers.toString(),
+                    inline: false,
                 },
             ])
             .setTimestamp();

--- a/src/lib/DatabaseController.ts
+++ b/src/lib/DatabaseController.ts
@@ -413,6 +413,17 @@ export class DatabaseController {
         }
     }
 
+    public async getMemberCount() {
+        try {
+            const result = await this.sequelize.models["GuildMembers"]?.count();
+
+            return result || 0;
+        } catch (error) {
+            logger.error(error, "Error retrieving member count from database");
+            return 0;
+        }
+    }
+
     public async getGuildMemberIdByUsername(username: string, guildId: string) {
         try {
             const result = await this.sequelize.models["GuildMembers"]?.findOne(


### PR DESCRIPTION
This pull request introduces a minor version update (`0.21.1`) with enhancements to the `/bot-stats` command, including displaying guild-member mappings, and updates the `package.json` file accordingly. Additionally, it adds a new method to the `DatabaseController` class to retrieve member counts from the database.

### Enhancements to `/bot-stats` command:

* [`src/commands/utility/stats.ts`](diffhunk://#diff-91f3491a1fa55de1ff733ce3f32d117e6518a1e0a9abd3b85ddf33f08e26dfabR26): Added `registeredMembers` to display the count of guild-member mappings in the stats embed. Updated embed fields to include "Guild-members Count" and changed the `inline` property for all fields to `false` for better formatting. [[1]](diffhunk://#diff-91f3491a1fa55de1ff733ce3f32d117e6518a1e0a9abd3b85ddf33f08e26dfabR26) [[2]](diffhunk://#diff-91f3491a1fa55de1ff733ce3f32d117e6518a1e0a9abd3b85ddf33f08e26dfabL36-R47)

### Database functionality:

* [`src/lib/DatabaseController.ts`](diffhunk://#diff-71dd30c5ebba0b1e2bb2a2b74f8063d2ef30c6845155b7a3b3e7725fdb12e218R416-R426): Added a new method `getMemberCount` to retrieve the count of guild-member mappings from the database, with error handling and logging.

### Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `0.21.0` to `0.21.1` to reflect the new changes.

### Changelog update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR22-R29): Added a new entry for version `0.21.1`, summarizing the changes and noting the addition of guild-member mappings to `/bot-stats`.