### PR TITLE
[0.25.0] Tightening down on meta team definitions and displaying what commands include sideboss in calculations

### DIFF
--- a/src/commands/guild-raid/metaTeamDistribution.ts
+++ b/src/commands/guild-raid/metaTeamDistribution.ts
@@ -100,7 +100,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             .setTitle(`Meta Team Distribution for Season ${season}`)
             .setColor(0x0099ff)
             .setDescription(
-                "This chart shows the distribution of meta teams in the specified season."
+                "This chart shows the distribution of meta teams in the specified season.\n Battles against sidebosses are not included in the calculation."
             )
             .setImage(`attachment://${attachment.name}`);
 

--- a/src/commands/guild-raid/seasonByRarity.ts
+++ b/src/commands/guild-raid/seasonByRarity.ts
@@ -145,7 +145,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             .setColor(0x0099ff)
             .setTitle(`Damage dealt in season ${season}`)
             .setDescription(
-                "The graph shows the damage dealt to individual guild bosses (does not include damage or tokens to primes):\n" +
+                "The graph shows the damage dealt to individual guild bosses\n" +
                     "- **Bar chart**: Damage dealt (left y-axis)\n" +
                     "- **Line chart**: Total tokens used (right y-axis)"
             )

--- a/src/commands/guild-raid/seasonHighscore.ts
+++ b/src/commands/guild-raid/seasonHighscore.ts
@@ -101,7 +101,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             )
             .addFields({
                 name: "Graph",
-                value: "The x axis contains the players and each line repsents the highest damage each user did against a specific boss",
+                value: "The x axis contains the players and each line repsents the highest damage each user did against a specific boss (not primes)",
             })
             .setImage(`attachment://season-${season}-highscores-${rarity}.png`);
 

--- a/src/commands/guild-raid/seasonParticipation.ts
+++ b/src/commands/guild-raid/seasonParticipation.ts
@@ -163,7 +163,8 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             .setDescription(
                 "The graph shows the contribution of each member to a guild raid season:\n" +
                     "- **Bar chart**: Damage dealt (left y-axis)\n" +
-                    "- **Line chart**: Total tokens used (right y-axis)"
+                    "- **Line chart**: Total tokens used (right y-axis)\n" +
+                    "- **Includes primes**: Yes"
             )
             .setFields(
                 {

--- a/src/commands/guild-raid/trackMember.ts
+++ b/src/commands/guild-raid/trackMember.ts
@@ -97,6 +97,8 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                 `Here are the guild raid stats for **${member}** over the last ${N_SEASONS} seasons.
                 
                 *Nb! Does not include inactive members in a season as it can only know who participated in prior seasons. This affects the average value if you had inactive players.*
+
+                Data includes primes.
                 `
             )
             .addFields({

--- a/src/lib/services/GuildService.ts
+++ b/src/lib/services/GuildService.ts
@@ -13,7 +13,7 @@ import {
     evaluateToken,
     getMetaTeams,
     getUnixTimestamp,
-    hasLynchpinHero,
+    hasLynchpinHeroes,
     inTeamsCheck,
     SecondsToString,
     testApiToken,
@@ -507,14 +507,12 @@ export class GuildService {
         const groupedResults: Record<string, GuildRaidResult[]> = {};
 
         for (const entry of entries) {
-            // Bombs don't count as damage
             if (!entry.userId) {
                 continue;
             }
 
             const boss = entry.type;
 
-            // Ensure groupedResults[boss] is initialized
             if (!groupedResults[boss]) {
                 groupedResults[boss] = [];
             }
@@ -523,7 +521,6 @@ export class GuildService {
             if (useUsernames) {
                 username = await dbController.getPlayerName(entry.userId);
                 if (!username) {
-                    // If a user is not registered or left the guild, we set their username to "Unknown"
                     username = "Unknown";
                 }
             } else {
@@ -535,9 +532,10 @@ export class GuildService {
             );
 
             if (existingUserEntry) {
+                // Bombs don't count as damage, but we want to know how many bombs were used
                 if (entry.damageType === DamageType.BOMB) {
                     existingUserEntry.bombCount++;
-                    continue; // Bombs don't count as damage
+                    continue;
                 }
                 existingUserEntry.totalDamage += entry.damageDealt;
                 existingUserEntry.totalTokens += 1;
@@ -724,7 +722,7 @@ export class GuildService {
                     throw new Error("teams[maxIndex] is somehow undefined");
                 }
 
-                if (!hasLynchpinHero(heroes, team)) {
+                if (!hasLynchpinHeroes(heroes, team)) {
                     totalDistribution.other += 1;
                     totalDistribution.otherDamage =
                         (totalDistribution.otherDamage || 0) +
@@ -883,7 +881,7 @@ export class GuildService {
                         throw new Error("teams[maxIndex] is somehow undefined");
                     }
 
-                    if (!hasLynchpinHero(heroes, team)) {
+                    if (!hasLynchpinHeroes(heroes, team)) {
                         totalDistribution.other += 1;
                         totalDistribution.otherDamage =
                             (totalDistribution.otherDamage || 0) +
@@ -1535,7 +1533,6 @@ export class GuildService {
                     .map((unit) => unit.id);
 
                 retval[player.details.name] = getMetaTeams(heroes);
-                // We now have all the heroes the player has and need to check what meta teams they have
             }
 
             return retval;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -176,18 +176,20 @@ export function inTeamsCheck(hero: string): TeamCheck {
     return teamCheck;
 }
 
-const lynchpinHeroes: Record<string, string> = {
-    multihit: "spaceBlackmane",
-    mech: "admecRuststalker",
-    psyker: "tyranNeurothrope",
+const lynchpinHeroes: Record<string, string[]> = {
+    multihit: ["spaceBlackmane"],
+    mech: ["admecRuststalker", "admecManipulus", "admecMarshall"],
+    psyker: ["tyranNeurothrope"],
 };
 
-export function hasLynchpinHero(heroes: string[], team: string): boolean {
-    const hero = lynchpinHeroes[team];
-    if (!hero) {
+export function hasLynchpinHeroes(heroes: string[], team: string): boolean {
+    const requiredHeroes = lynchpinHeroes[team];
+    if (!requiredHeroes || requiredHeroes.length === 0) {
         return false;
     }
-    return heroes.includes(hero);
+    return requiredHeroes.every((requiredHero) =>
+        heroes.includes(requiredHero)
+    );
 }
 
 export function getMetaTeam(heroes: string[]): MetaTeams {
@@ -204,15 +206,15 @@ export function getMetaTeam(heroes: string[]): MetaTeams {
         if (check.inPsyker) distribution.neuro++;
     });
 
-    if (distribution.mh >= 3 && hasLynchpinHero(heroes, "multihit")) {
+    if (distribution.mh >= 5 && hasLynchpinHeroes(heroes, "multihit")) {
         return MetaTeams.MH;
     }
 
-    if (distribution.admech >= 3 && hasLynchpinHero(heroes, "mech")) {
+    if (distribution.admech >= 5 && hasLynchpinHeroes(heroes, "mech")) {
         return MetaTeams.ADMECH;
     }
 
-    if (distribution.neuro >= 3 && hasLynchpinHero(heroes, "psyker")) {
+    if (distribution.neuro >= 5 && hasLynchpinHeroes(heroes, "psyker")) {
         return MetaTeams.NEURO;
     }
 
@@ -239,14 +241,14 @@ export function getMetaTeams(heroes: string[]): MetaComps {
         if (check.inPsyker) distribution.neuro++;
     });
 
-    if (distribution.multihit >= 5 && hasLynchpinHero(heroes, "multihit")) {
+    if (distribution.multihit >= 5 && hasLynchpinHeroes(heroes, "multihit")) {
         retval.multihit = true;
     }
 
-    if (distribution.admech >= 5 && hasLynchpinHero(heroes, "mech")) {
+    if (distribution.admech >= 5 && hasLynchpinHeroes(heroes, "mech")) {
         retval.admech = true;
     }
-    if (distribution.neuro >= 5 && hasLynchpinHero(heroes, "psyker")) {
+    if (distribution.neuro >= 5 && hasLynchpinHeroes(heroes, "psyker")) {
         retval.neuro = true;
     }
 

--- a/src/test/services/DataTranformationServiceSuite.test.ts
+++ b/src/test/services/DataTranformationServiceSuite.test.ts
@@ -175,7 +175,7 @@ describe("DataTransformationServiceSuite - Algebra", () => {
                 {
                     username: "test1",
                     value: 200,
-                    team: "Multihit",
+                    team: "Other",
                 },
                 {
                     username: "test2",

--- a/src/test/utilsSuite.test.ts
+++ b/src/test/utilsSuite.test.ts
@@ -4,7 +4,7 @@ import {
     getAllCommands,
     getTopNDamageDealers,
     getUnixTimestamp,
-    hasLynchpinHero,
+    hasLynchpinHeroes,
     inTeamsCheck,
     namedColor,
     sortGuildRaidResultDesc,
@@ -66,28 +66,28 @@ describe("utilsSuite - Algebra", () => {
         });
     });
 
-    test("hasLynchpinHero - Should provide true/false if lynchpin in team or not ", () => {
+    test("hasLynchpinHero - Should provide true/false if lynchpins in team or not ", () => {
         const teams: string[][] = [
             ["ultraInceptorSgt", "orksWarboss", "eldarFarseer"],
             ["orksRuntherd", "eldarAutarch", "ultraInceptorSgt"],
             ["spaceBlackmane", "orksRuntherd", "eldarFarseer"],
             ["tyraanNeurothrope", "orksRuntherd", "eldarAutarch"],
-            ["admecRuststalker", "orksRuntherd", "eldarFarseer"],
+            ["admecRuststalker", "admecMarshall", "admecManipulus"],
             ["tyranNeurothrope", "orksRuntherd", "eldarAutarch"],
         ];
 
         const psykerTeam = teams.reduce(
-            (acc, team) => acc + Number(hasLynchpinHero(team, "psyker")),
+            (acc, team) => acc + Number(hasLynchpinHeroes(team, "psyker")),
             0
         );
 
         const multiTeam = teams.reduce(
-            (acc, team) => acc + Number(hasLynchpinHero(team, "multihit")),
+            (acc, team) => acc + Number(hasLynchpinHeroes(team, "multihit")),
             0
         );
 
         const mechTeam = teams.reduce(
-            (acc, team) => acc + Number(hasLynchpinHero(team, "mech")),
+            (acc, team) => acc + Number(hasLynchpinHeroes(team, "mech")),
             0
         );
 
@@ -335,9 +335,9 @@ describe("utilsSuite - Algebra", () => {
     test("getMetaTeam - Should return the correct meta team", () => {
         const multihitTeam = [
             "ultraInceptorSgt",
-            "tauCrisis",
+            "orksWarboss",
             "eldarFarseer",
-            "admecRuststalker",
+            "templHelbrecht",
             "spaceBlackmane",
         ];
         const metaTeam = getMetaTeam(multihitTeam);
@@ -346,9 +346,9 @@ describe("utilsSuite - Algebra", () => {
         const admechTeam = [
             "necroSpyder",
             "admecRuststalker",
-            "eldarFarseer",
+            "tauCrisis",
             "admecMarshall",
-            "spaceBlackmane",
+            "admecDominus",
             "admecManipulus",
         ];
 
@@ -357,8 +357,8 @@ describe("utilsSuite - Algebra", () => {
             "eldarFarseer",
             "tyranNeurothrope",
             "genesMagus",
-            "necroSpyder",
-            "templHelbrecht",
+            "adeptCanoness",
+            "bloodMephiston",
         ];
         expect(getMetaTeam(neuroTeam)).toEqual(MetaTeams.NEURO);
     });


### PR DESCRIPTION
This pull request introduces several updates to improve the functionality and accuracy of guild raid-related features, focusing on refining meta team calculations, clarifying descriptions, and enhancing test coverage. The most significant changes include updates to the logic for identifying lynchpin heroes, adjustments to meta team thresholds, and descriptive improvements in user-facing messages.

### Meta Team Logic Enhancements:
* Updated the `lynchpinHeroes` structure to support multiple required heroes per team and replaced the `hasLynchpinHero` function with `hasLynchpinHeroes` for better accuracy in determining meta team eligibility. This change affects multiple methods, including `getMetaTeam` and `getMetaTeams` (`src/lib/utils.ts`). [[1]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L179-R192) [[2]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L207-R217) [[3]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L242-R251)
* Increased the threshold for meta team qualification from 3 to 5 heroes for multihit, admech, and psyker teams to ensure stricter validation (`src/lib/utils.ts`). [[1]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L207-R217) [[2]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L242-R251)

### User-Facing Description Updates:
* Clarified descriptions in several commands to better inform users about data inclusions and exclusions, such as explicitly mentioning whether primes or side bosses are included in calculations (`src/commands/guild-raid/metaTeamDistribution.ts`, `src/commands/guild-raid/seasonParticipation.ts`, etc.). [[1]](diffhunk://#diff-6bb839008e4b5c05a582cebe91b3aed720c2990118a4afc7233dc139959de415L103-R103) [[2]](diffhunk://#diff-f5d31196b2bd2f818dad194270fae224c789700a7c463aaf61d581ca350b2a0aL148-R148) [[3]](diffhunk://#diff-0b5e8a60ea9130a1a4c13d9885bd6b7a6a4b4446377a0b27c8678279084a2f82L166-R167) [[4]](diffhunk://#diff-7c198969595959d8d7edf3adaddc504c1ed6ae5819ce6c434ba63c95fcc322d2R100-R101)

### Code Cleanup and Refactoring:
* Removed outdated or redundant comments in the `GuildService` class to improve code readability (`src/lib/services/GuildService.ts`). [[1]](diffhunk://#diff-367f499f4273ff233fddc6cb4631abfe25fafd74be1a59308aee9e73ede49adaL510-L517) [[2]](diffhunk://#diff-367f499f4273ff233fddc6cb4631abfe25fafd74be1a59308aee9e73ede49adaL526) [[3]](diffhunk://#diff-367f499f4273ff233fddc6cb4631abfe25fafd74be1a59308aee9e73ede49adaL1538)

### Test Suite Updates:
* Updated test cases to align with the new `hasLynchpinHeroes` logic and stricter meta team thresholds, ensuring comprehensive validation of the revised functionality (`src/test/utilsSuite.test.ts`). [[1]](diffhunk://#diff-2dfb770e4b748e99235b8ecde469aad81f14cdc3044120d47a16c523d2d92dd7L69-R90) [[2]](diffhunk://#diff-2dfb770e4b748e99235b8ecde469aad81f14cdc3044120d47a16c523d2d92dd7L338-R340) [[3]](diffhunk://#diff-2dfb770e4b748e99235b8ecde469aad81f14cdc3044120d47a16c523d2d92dd7L349-R351) [[4]](diffhunk://#diff-2dfb770e4b748e99235b8ecde469aad81f14cdc3044120d47a16c523d2d92dd7L360-R361)
* Adjusted test data to reflect the updated requirements for meta team eligibility (`src/test/services/DataTranformationServiceSuite.test.ts`).

These changes collectively enhance the accuracy, clarity, and maintainability of the guild raid features and their associated tests.