### PR TITLE
Add command to simplify adding users to memberlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - -->
 
+## [0.27.0] - 2025-07-21
+
+This update aims to simplify the process of adding new members to the memberlist when they join your guild by bringing a new command. Now when a member joins your guild you can use this one command and just provide their username. No need for copy-pasting IDs anymore.
+
+### Added
+
+-   **New command!** - `/add-username`. Updates the username of the first member in the memberlist that doesn't have a registered username.
+
 ## [0.26.0] - 2025-07-20
 
 This patch aims to provide more clarity to users regarding how to use the bot and adds optional rarity filter to `/season-participation`.
 
-## Added
+### Added
 
 -   `/season-participation` now has an optional rarity filter.
 -   `/help` now has link buttons to the support channel and github repository
 
-## Changed
+### Changed
 
 -   `/meta-team-distribution` now has additional information regarding the charts. Hopefully these make them easier to understand.
 -   `/help` now has more detailed explanation regarding registering for the bot

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "0.26.0",
+    "version": "0.27.0",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/commands/guild-management/addUsername.ts
+++ b/src/commands/guild-management/addUsername.ts
@@ -1,0 +1,123 @@
+import { logger } from "@/lib";
+import { GuildService } from "@/lib/services/GuildService";
+import {
+    ChatInputCommandInteraction,
+    MessageFlags,
+    SlashCommandBuilder,
+} from "discord.js";
+
+export const cooldown = 5;
+
+export const data = new SlashCommandBuilder()
+    .setName("add-username")
+    .setDescription(
+        "Add username to the first member in the memberlist without a username"
+    )
+    .addStringOption((option) =>
+        option
+            .setName("username")
+            .setDescription("The username of the member")
+            .setRequired(true)
+            .setMinLength(1)
+    );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    try {
+        const username = interaction.options.getString("username", true);
+        if (!username || username.length < 0) {
+            await interaction.editReply({
+                content: "Please provide a valid username.",
+                options: {
+                    flags: MessageFlags.Ephemeral,
+                },
+            });
+            return;
+        }
+
+        const service = new GuildService();
+
+        // First get all active members of the guild
+        const members = await service.getGuildMembers(interaction.user.id);
+        if (!members || members.length === 0) {
+            await interaction.editReply({
+                content: "No members found in the guild.",
+                options: {
+                    flags: MessageFlags.Ephemeral,
+                },
+            });
+            return;
+        }
+
+        const memberDataPromises = members.map(async (member) => {
+            const username = await service.getUsernameById(member);
+            return { [member]: username ?? "replace-with-username" };
+        });
+        const memberDataArray = await Promise.all(memberDataPromises);
+
+        // Find the first member with username 'replace-with-username'
+        const recentMember = memberDataArray.find(
+            (member) => Object.values(member)[0] === "replace-with-username"
+        );
+
+        if (!recentMember) {
+            await interaction.editReply({
+                content: "No recent member found without a username",
+                options: {
+                    flags: MessageFlags.Ephemeral,
+                },
+            });
+            return;
+        }
+
+        const recentMemberId = Object.keys(recentMember)[0];
+        if (!recentMemberId) {
+            await interaction.editReply({
+                content: "No recent member found without a user ID",
+                options: {
+                    flags: MessageFlags.Ephemeral,
+                },
+            });
+            return;
+        }
+
+        const guildId = await service.getGuildId(interaction.user.id);
+        if (!guildId) {
+            await interaction.editReply({
+                content: "Did not find a guild for your user ID.",
+                options: {
+                    flags: MessageFlags.Ephemeral,
+                },
+            });
+            return;
+        }
+
+        const result = await service.updateGuildMember(
+            recentMemberId,
+            username,
+            guildId
+        );
+
+        if (result) {
+            await interaction.editReply({
+                content: `Successfully added recent member with ID \`${recentMemberId}\` and username \`${username}\` to the guild.`,
+            });
+        } else {
+            await interaction.editReply({
+                content: "Failed to add the recent member to the guild.",
+                options: {
+                    flags: MessageFlags.Ephemeral,
+                },
+            });
+        }
+    } catch (error) {
+        logger.error(error, "Error while adding recent member");
+        await interaction.editReply({
+            content: "An error occurred while adding the recent member.",
+            options: {
+                flags: MessageFlags.Ephemeral,
+            },
+        });
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature to simplify guild management by adding a command to update the username of guild members. It also includes version updates and documentation changes to reflect this new feature.

### New Feature: Guild Management Command
* Added a new command `/add-username` that updates the username of the first member in the guild's memberlist without a registered username. This command includes validation, error handling, and integration with the `GuildService` for member updates. (`src/commands/guild-management/addUsername.ts`)

### Documentation Updates
* Updated `CHANGELOG.md` to include details about the new `/add-username` command in version `0.27.0`. (`CHANGELOG.md`)

### Version Update
* Incremented the package version from `0.26.0` to `0.27.0` in `package.json`. (`package.json`)