### PR TITLE
Hotfix 0.29.1 include primes descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - -->
 
+## [0.29.1] - 2025-07-28
+
+A small fix to some command descriptions regarding whether or not they include primes in their calculations.
+
+### Fixed
+
+-   `/member-stats-per-season` - Description now correctly informs that the stats include primes in the calculations.
+
+### Added
+
+-   Added explicit confirmation that commands include primes to:
+    -   `/inactivity-by-season`
+    -   `/season-tokens`
+    -   `/season-participation`
+
 ## [0.29.0] - 2025-07-28
 
 This patch is mostly a maintenance patch on the technical side of things. Bit of oil to the cogs, if you will. The patch also brings a minor bugfix and some reliability improvements.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "0.29.0",
+    "version": "0.29.1",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/commands/guild-raid/inactivityBySeason.ts
+++ b/src/commands/guild-raid/inactivityBySeason.ts
@@ -74,7 +74,8 @@ export async function execute(interaction: ChatInputCommandInteraction) {
         const result = await service.getGuildRaidResultBySeason(
             interaction.user.id,
             season,
-            rarity
+            rarity,
+            true
         );
 
         if (
@@ -154,8 +155,9 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             .setColor(0x0099ff)
             .setDescription(
                 "The number of players who did not use the required number of tokens:\n" +
-                    `- **Threshold**: ${threshold} token(s)\n` + // Ensure no extra spaces or indentation
-                    `- **Rarity:** ${rarity ?? "All Rarities"}\n` // Keep this aligned with the previous line
+                    `- **Threshold**: ${threshold} token(s)\n` +
+                    `- **Rarity:** ${rarity ?? "All Rarities"}\n` +
+                    "- **Includes primes:** Yes\n"
             )
             .setFields([
                 {

--- a/src/commands/guild-raid/memberStatsBySeason.ts
+++ b/src/commands/guild-raid/memberStatsBySeason.ts
@@ -165,12 +165,10 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             .setColor("#0099ff")
             .setTitle("Member stats for season " + season)
             .setDescription(
-                `See the detailed statistics for each member in the specified season.
-
-                :family: - Team distribution used by the player
-                :bar_chart: - Percentage of total damage dealt by meta teams
-
-                *Note that team distribution does not include data from sidebosses/primes*`
+                "See the detailed statistics for each member in the specified season.\n\n" +
+                    ":family: - Team distribution used by the player\n" +
+                    ":bar_chart: - Percentage of total damage dealt by meta teams\n\n" +
+                    "**Includes primes:** Yes"
             )
             .setTimestamp();
 

--- a/src/commands/guild-raid/seasonParticipation.ts
+++ b/src/commands/guild-raid/seasonParticipation.ts
@@ -104,7 +104,8 @@ export async function execute(interaction: ChatInputCommandInteraction) {
         const result = await service.getGuildRaidResultBySeason(
             interaction.user.id,
             season,
-            rarity
+            rarity,
+            true
         );
 
         if (

--- a/src/commands/guild-raid/seasonTokens.ts
+++ b/src/commands/guild-raid/seasonTokens.ts
@@ -83,7 +83,8 @@ export async function execute(interaction: ChatInputCommandInteraction) {
         const result = await service.getGuildRaidResultBySeason(
             interaction.user.id,
             season,
-            rarity
+            rarity,
+            true
         );
 
         if (
@@ -163,7 +164,8 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             .setDescription(
                 `The graph shows the number of tokens used by each member in season ${season}.\n` +
                     "- **Bar chart:** the number of tokens used by each member.\n" +
-                    `- **Line chart:** represents the ${averageMethod.toLowerCase()} number of tokens used by the guild.`
+                    `- **Line chart:** represents the ${averageMethod.toLowerCase()} number of tokens used by the guild.\n` +
+                    "- **Includes primes:** Yes\n"
             )
             .addFields(
                 {


### PR DESCRIPTION

### Documentation Updates:

* Updated the `CHANGELOG.md` to include the release notes for version `0.29.1`. This version highlights fixes to command descriptions and explicitly confirms whether primes are included in calculations for specific commands. (`[CHANGELOG.mdR22-R36](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR22-R36)`)

### Code Adjustments:

* Updated the `package.json` to reflect the new version `0.29.1`. (`[package.jsonL4-R4](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4)`)
* Modified the `/inactivity-by-season`, `/season-tokens`, and `/season-participation` commands to pass an additional parameter (`true`) to explicitly include primes in their calculations. (`[[1]](diffhunk://#diff-ba7a67e35ac9998c56527ef9fd5e15ea5dd47e1d72365b788341fbbfb5041de8L77-R78)`, `[[2]](diffhunk://#diff-0b5e8a60ea9130a1a4c13d9885bd6b7a6a4b4446377a0b27c8678279084a2f82L107-R108)`, `[[3]](diffhunk://#diff-973401a95c5635438c4e3c3bc1074daed9c229f2d7a74078b3f2f5d694f9551eL86-R87)`)
* Updated the descriptions in `/inactivity-by-season`, `/season-tokens`, and `/member-stats-per-season` commands to explicitly state that primes are included. (`[[1]](diffhunk://#diff-ba7a67e35ac9998c56527ef9fd5e15ea5dd47e1d72365b788341fbbfb5041de8L157-R160)`, `[[2]](diffhunk://#diff-973401a95c5635438c4e3c3bc1074daed9c229f2d7a74078b3f2f5d694f9551eL166-R168)`, `[[3]](diffhunk://#diff-0746e6062101e01c6354fc6bf97c58ef29b8332a5c3e2d4c307b6f42c7ed16b5L168-R171)`)