### PR TITLE
Update chart label for prime damage portion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - -->
 
+## [0.31.1] - 2025-08-06
+
+Quick patch to clarify that the bars are stacked in `/season-by-rarity`, not overlays. The blue value is damage dealt to the boss and the purple bar is damage dealt to primes.
+
+### Changed
+
+-   Changed embed description of `season-by-rarity` to make it more clear that the bars are stacked.
+-   Removed datalabels in `season-by-rarity` when they're 0
+
 ## [0.31.0] - 2025-08-05
 
 The server is now back up and running, stronger than ever, and with it comes a new update focused on improving the details provided in graphs. I can only thank you for your patience these last couple of days. The Machine spirit should now be satisfied and stable for the foreseeable future.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "0.31.0",
+    "version": "0.31.1",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/commands/guild-raid/seasonByRarity.ts
+++ b/src/commands/guild-raid/seasonByRarity.ts
@@ -146,10 +146,10 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             .setTitle(`Damage dealt in season ${season}`)
             .setDescription(
                 "The graph shows the damage dealt to individual guild bosses\n" +
-                    "- Blue bars (left y-axis): Total damage dealt to boss, including primes\n" +
+                    "- Blue bars (left y-axis): Total damage dealt to boss\n" +
                     "- Red line (leftmost y-axis): Avg damage per token\n" +
                     "- Orange line (right y-axis): Total tokens used\n" +
-                    "- Purple bars (left y-axis): Portion of damage dealt to primes\n" +
+                    "- Purple bars (left y-axis): Damage dealt to primes\n" +
                     "- Yellow dotted line (left y-axis): Guild average damage"
             )
             .setImage("attachment://graph-0.png"); // Set the first chart as the main image

--- a/src/lib/services/ChartService.ts
+++ b/src/lib/services/ChartService.ts
@@ -273,7 +273,7 @@ export class ChartService {
                     },
                     {
                         backgroundColor: CHART_COLORS.purple,
-                        label: "Prime damage portion",
+                        label: "Prime damage",
                         data: primeDamage,
                         borderWidth: 1,
                         datalabels: {

--- a/src/lib/services/ChartService.ts
+++ b/src/lib/services/ChartService.ts
@@ -267,7 +267,7 @@ export class ChartService {
                                 size: 11,
                             },
                             formatter: function (value: number) {
-                                return shortenNumber(value);
+                                return value > 0 ? shortenNumber(value) : null;
                             },
                         },
                     },
@@ -303,7 +303,7 @@ export class ChartService {
                                 size: 11,
                             },
                             formatter: function (value: number) {
-                                return shortenNumber(value);
+                                return value > 0 ? shortenNumber(value) : null;
                             },
                         },
                     },


### PR DESCRIPTION
This pull request makes a minor update to the label for the prime damage dataset in the chart configuration within the `ChartService` class. The label has been shortened for clarity.