### PR TITLE
[0.32.0] Mythic boss update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "0.31.2",
+    "version": "0.32.0",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/commands/guild-management/getMetaComps.ts
+++ b/src/commands/guild-management/getMetaComps.ts
@@ -19,7 +19,8 @@ export const data = new SlashCommandBuilder()
                 { name: "Bronze", value: 6 },
                 { name: "Silver", value: 9 },
                 { name: "Gold", value: 12 },
-                { name: "Diamond", value: 15 }
+                { name: "Diamond", value: 15 },
+                { name: "Adamantium", value: 18 }
             )
             .setRequired(false)
     );

--- a/src/commands/guild-raid/availableBombs.ts
+++ b/src/commands/guild-raid/availableBombs.ts
@@ -1,0 +1,150 @@
+import { logger } from "@/lib";
+import { GuildService } from "@/lib/services/GuildService";
+import {
+    ChatInputCommandInteraction,
+    EmbedBuilder,
+    SlashCommandBuilder,
+} from "discord.js";
+
+export const cooldown = 5;
+
+export const data = new SlashCommandBuilder()
+    .setName("available-bombs")
+    .setDescription("See who has bombs available");
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply();
+
+    const service = new GuildService();
+
+    logger.info(`${interaction.user.id} attempting to use /available-bombs`);
+
+    try {
+        const result = await service.getAvailableBombs(interaction.user.id);
+
+        if (
+            !result ||
+            typeof result !== "object" ||
+            Object.keys(result).length === 0 ||
+            result === null
+        ) {
+            await interaction.editReply({
+                content:
+                    "No data found for the current season. Ensure you are registered and have the correct permissions.",
+            });
+            return;
+        }
+
+        // Add players who have not used any tokens or bombs yet
+        const guildId = await service.getGuildId(interaction.user.id);
+        if (!guildId) {
+            await interaction.editReply({
+                content:
+                    "Could not find your guild's ID. Please make sure you have registered your API-token",
+            });
+            return;
+        }
+
+        const players = await service.getPlayerList(guildId);
+        if (!players || players.length === 0) {
+            await interaction.editReply({
+                content:
+                    "No players found in the guild. Please make sure you have registered your API-token",
+            });
+            return;
+        }
+
+        const playersNotParticipated = players.filter(
+            (player) => !result[player.username]
+        );
+
+        playersNotParticipated.forEach((player) => {
+            result[player.username] = {
+                tokens: 3,
+                bombs: 1,
+                tokenCooldown: undefined,
+                bombCooldown: undefined,
+            };
+        });
+
+        const totalBombs = Object.values(result).reduce(
+            (acc, available) => acc + available.bombs,
+            0
+        );
+
+        let maxBombs = Object.keys(result).length;
+        maxBombs = maxBombs > 30 ? 30 : maxBombs;
+
+        const formattedTotalBombs = `Total bombs: \`${totalBombs}/${maxBombs}\``;
+
+        const table = Object.entries(result)
+            .map(([userId, available]) => {
+                const bombIcon = available.bombs > 0 ? "✅" : `❌`;
+
+                let bombStatus: string;
+                if (!available.bombCooldown) {
+                    bombStatus = `${bombIcon} \`READY..\``;
+                } else {
+                    bombStatus = `${bombIcon} \`${
+                        available.bombs > 0 ? "+" : "-"
+                    }${available.bombCooldown.slice(0, -4).replace(" ", "")}\``;
+                }
+
+                return {
+                    text: `${bombStatus} - ${userId}`,
+                    bombs: available.bombs,
+                };
+            })
+            .sort((a, b) => b.bombs - a.bombs)
+            .map((item) => item.text);
+
+        if (table.length === 0) {
+            await interaction.editReply({
+                content: "No members have available bombs right now.",
+            });
+            return;
+        }
+
+        const embed = new EmbedBuilder()
+            .setColor("#0099ff")
+            .setTitle("Available Bombs")
+            .setDescription("Here is the list of members with available bombs.")
+            .setTimestamp();
+
+        for (let i = 0; i < table.length; i += 10) {
+            embed.addFields({
+                name: "",
+                value: table.slice(i, i + 10).join("\n"),
+                inline: false,
+            });
+        }
+
+        embed.addFields(
+            {
+                name: "Total bombs",
+                value: formattedTotalBombs,
+                inline: true,
+            },
+            {
+                name: "Copy-paste players with available bombs",
+                value:
+                    "```" +
+                    (Object.entries(result)
+                        .filter(([, available]) => available.bombs > 0)
+                        .map(([username]) => `@${username}`)
+                        .join("\n") || "None") +
+                    "```",
+            }
+        );
+
+        await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+        logger.error(
+            error,
+            `${interaction.user.id} failed to use /available-bombs`
+        );
+        await interaction.editReply(
+            "There was an error while fetching available bombs."
+        );
+    }
+}

--- a/src/commands/guild-raid/guildRaidAvailability.ts
+++ b/src/commands/guild-raid/guildRaidAvailability.ts
@@ -87,7 +87,10 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             0
         );
 
-        const formattedTotalBombs = `Total bombs: \`${totalBombs}/${players.length}\``;
+        let maxBombs = Object.keys(result).length;
+        maxBombs = maxBombs > 30 ? 30 : maxBombs;
+
+        const formattedTotalBombs = `Total bombs: \`${totalBombs}/${maxBombs}\``;
 
         const table = Object.entries(result)
             .map(([userId, available]) => {

--- a/src/commands/guild-raid/guildRaidTimeUsed.ts
+++ b/src/commands/guild-raid/guildRaidTimeUsed.ts
@@ -27,6 +27,7 @@ export const data = new SlashCommandBuilder()
             .setDescription("The rarity of the boss")
             .setRequired(false)
             .addChoices(
+                { name: "Mythic", value: Rarity.MYTHIC },
                 { name: "Legendary", value: Rarity.LEGENDARY },
                 { name: "Epic", value: Rarity.EPIC },
                 { name: "Rare", value: Rarity.RARE },

--- a/src/commands/guild-raid/inactivityBySeason.ts
+++ b/src/commands/guild-raid/inactivityBySeason.ts
@@ -39,6 +39,7 @@ export const data = new SlashCommandBuilder()
             .setDescription("The rarity of the boss")
             .setRequired(false)
             .addChoices(
+                { name: "Mythic", value: Rarity.MYTHIC },
                 { name: "Legendary", value: Rarity.LEGENDARY },
                 { name: "Epic", value: Rarity.EPIC },
                 { name: "Rare", value: Rarity.RARE },

--- a/src/commands/guild-raid/memberStatsBySeason.ts
+++ b/src/commands/guild-raid/memberStatsBySeason.ts
@@ -36,6 +36,7 @@ export const data = new SlashCommandBuilder()
             .setDescription("The rarity of the boss")
             .setRequired(false)
             .addChoices(
+                { name: "Mythic", value: Rarity.MYTHIC },
                 { name: "Legendary", value: Rarity.LEGENDARY },
                 { name: "Epic", value: Rarity.EPIC },
                 { name: "Rare", value: Rarity.RARE },

--- a/src/commands/guild-raid/metaTeamDistribution.ts
+++ b/src/commands/guild-raid/metaTeamDistribution.ts
@@ -27,6 +27,7 @@ export const data = new SlashCommandBuilder()
             .setDescription("The rarity of the boss")
             .setRequired(false)
             .addChoices(
+                { name: "Mythic", value: Rarity.MYTHIC },
                 { name: "Legendary", value: Rarity.LEGENDARY },
                 { name: "Epic", value: Rarity.EPIC },
                 { name: "Rare", value: Rarity.RARE },

--- a/src/commands/guild-raid/seasonBosses.ts
+++ b/src/commands/guild-raid/seasonBosses.ts
@@ -20,6 +20,7 @@ export const data = new SlashCommandBuilder()
             .setDescription("The rarity of the boss")
             .setRequired(false)
             .addChoices(
+                { name: "Mythic", value: Rarity.MYTHIC },
                 { name: "Legendary", value: Rarity.LEGENDARY },
                 { name: "Epic", value: Rarity.EPIC },
                 { name: "Rare", value: Rarity.RARE },

--- a/src/commands/guild-raid/seasonByRarity.ts
+++ b/src/commands/guild-raid/seasonByRarity.ts
@@ -32,6 +32,7 @@ export const data = new SlashCommandBuilder()
             .setDescription("The rarity of the boss")
             .setRequired(true)
             .addChoices(
+                { name: "Mythic", value: Rarity.MYTHIC },
                 { name: "Legendary", value: Rarity.LEGENDARY },
                 { name: "Epic", value: Rarity.EPIC },
                 { name: "Rare", value: Rarity.RARE },

--- a/src/commands/guild-raid/seasonHighscore.ts
+++ b/src/commands/guild-raid/seasonHighscore.ts
@@ -30,6 +30,7 @@ export const data = new SlashCommandBuilder()
             .setDescription("The rarity of the boss")
             .setRequired(true)
             .addChoices(
+                { name: "Mythic", value: Rarity.MYTHIC },
                 { name: "Legendary", value: Rarity.LEGENDARY },
                 { name: "Epic", value: Rarity.EPIC },
                 { name: "Rare", value: Rarity.RARE },

--- a/src/commands/guild-raid/seasonParticipation.ts
+++ b/src/commands/guild-raid/seasonParticipation.ts
@@ -33,6 +33,7 @@ export const data = new SlashCommandBuilder()
             .setDescription("The rarity of the boss")
             .setRequired(false)
             .addChoices(
+                { name: "Mythic", value: Rarity.MYTHIC },
                 { name: "Legendary", value: Rarity.LEGENDARY },
                 { name: "Epic", value: Rarity.EPIC },
                 { name: "Rare", value: Rarity.RARE },

--- a/src/commands/guild-raid/seasonTokens.ts
+++ b/src/commands/guild-raid/seasonTokens.ts
@@ -31,6 +31,7 @@ export const data = new SlashCommandBuilder()
             .setDescription("The rarity of the boss")
             .setRequired(false)
             .addChoices(
+                { name: "Mythic", value: Rarity.MYTHIC },
                 { name: "Legendary", value: Rarity.LEGENDARY },
                 { name: "Epic", value: Rarity.EPIC },
                 { name: "Rare", value: Rarity.RARE },

--- a/src/commands/guild-raid/trackMember.ts
+++ b/src/commands/guild-raid/trackMember.ts
@@ -30,6 +30,7 @@ export const data = new SlashCommandBuilder()
             .setDescription("The rarity of the boss")
             .setRequired(false)
             .addChoices(
+                { name: "Mythic", value: Rarity.MYTHIC },
                 { name: "Legendary", value: Rarity.LEGENDARY },
                 { name: "Epic", value: Rarity.EPIC },
                 { name: "Rare", value: Rarity.RARE },

--- a/src/commands/guild-raid/trackMember.ts
+++ b/src/commands/guild-raid/trackMember.ts
@@ -267,16 +267,30 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                         " " +
                         boss.split(/(?=[A-Z])/)[0]?.substring(0, 4);
 
-                    userStatsPerBoss[bossName] = [userAvg, relativeDamage];
+                    const maxDmg = (userData.maxDmg || 0).toLocaleString(
+                        undefined,
+                        {
+                            maximumFractionDigits: 0,
+                        }
+                    );
+
+                    userStatsPerBoss[bossName] = [
+                        userAvg,
+                        relativeDamage,
+                        maxDmg,
+                    ];
                 }
 
                 const bossRelativeStrings = Object.entries(userStatsPerBoss)
                     .map(([bossname, user]) => {
                         const userAvgStr = user[0];
                         const userRelativeTotal = user[1];
+                        const userMaxDmg = user[2];
                         return `${bossname.padEnd(8)} ${userAvgStr!.padStart(
                             10
-                        )} ${userRelativeTotal!.padStart(8)}`;
+                        )} ${userRelativeTotal!.padStart(
+                            8
+                        )} ${userMaxDmg!.padStart(10)}`;
                     })
                     .join("\n");
 
@@ -295,8 +309,10 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                         { maximumFractionDigits: 1 }
                     )}\` — User tokens: \`${userTokens}\` — Relative Tokens: \`${relativeTokens}\`
                     \`\`\`${"Boss".padEnd(6)} ${"User Avg".padEnd(
-                        12
-                    )} Rel. total\n${bossRelativeStrings}\`\`\``,
+                        10
+                    )} ${"Rel. total".padEnd(12)} ${"Max Dmg".padEnd(
+                        8
+                    )}\n${bossRelativeStrings}\`\`\``,
                 });
             }
         }

--- a/src/lib/services/GuildService.ts
+++ b/src/lib/services/GuildService.ts
@@ -416,6 +416,9 @@ export class GuildService {
             Array.from(allUserIds)
         );
 
+        const unknownUserMap = new Map<string, string>();
+        let unknownCounter = 1;
+
         for (const entry of entries) {
             // Bombs don't count as damage
             if (!entry.userId) {
@@ -429,7 +432,19 @@ export class GuildService {
                 continue;
             }
 
-            const username = usernames[entry.userId] || "Unknown";
+            let username = usernames[entry.userId];
+            if (!username) {
+                // Check if we already assigned a number to this unknown user
+                if (!unknownUserMap.has(entry.userId)) {
+                    unknownUserMap.set(
+                        entry.userId,
+                        `Unknown ${unknownCounter}`
+                    );
+                    unknownCounter++;
+                }
+                username = unknownUserMap.get(entry.userId)!;
+            }
+
             const existingEntry = damagePeruser.find(
                 (e) => e.username === username
             );
@@ -523,6 +538,9 @@ export class GuildService {
             Array.from(allUserIds)
         );
 
+        const unknownUserMap = new Map<string, string>();
+        let unknownCounter = 1;
+
         const groupedResults: Record<string, GuildRaidResult[]> = {};
 
         for (const entry of entries) {
@@ -536,9 +554,20 @@ export class GuildService {
                 groupedResults[boss] = [];
             }
 
-            let username: string | null = null;
+            let username: string | undefined = undefined;
             if (useUsernames) {
-                username = usernames[entry.userId] || "Unknown";
+                username = usernames[entry.userId];
+                if (!username) {
+                    // Check if we already assigned a number to this unknown user
+                    if (!unknownUserMap.has(entry.userId)) {
+                        unknownUserMap.set(
+                            entry.userId,
+                            `Unknown ${unknownCounter}`
+                        );
+                        unknownCounter++;
+                    }
+                    username = unknownUserMap.get(entry.userId)!;
+                }
             } else {
                 username = entry.userId;
             }
@@ -646,9 +675,24 @@ export class GuildService {
             Array.from(allUserIds)
         );
 
+        const unknownUserMap = new Map<string, string>();
+        let unknownCounter = 1;
+
         const bombsPerUser: Record<string, number> = {};
         for (const bomb of bombs) {
-            const username = usernames[bomb.userId] || "Unknown";
+            let username = usernames[bomb.userId];
+
+            if (!username) {
+                // Check if we already assigned a number to this unknown user
+                if (!unknownUserMap.has(bomb.userId)) {
+                    unknownUserMap.set(
+                        bomb.userId,
+                        `Unknown ${unknownCounter}`
+                    );
+                    unknownCounter++;
+                }
+                username = unknownUserMap.get(bomb.userId)!;
+            }
 
             bombsPerUser[username] = (bombsPerUser[username] ?? 0) + 1;
         }
@@ -838,12 +882,25 @@ export class GuildService {
             const allUserIds = Object.keys(groupedResults);
             const allUsernames = await dbController.getPlayerNames(allUserIds);
 
+            const unknownUserMap = new Map<string, string>();
+            let unknownCounter = 1;
+
             const result: Record<string, TeamDistribution> = {};
             for (const key in groupedResults) {
                 // Replace ID with username
                 const entries = groupedResults[key];
-                const username = allUsernames[key] || "Unknown";
-                if (!username || !entries) {
+                let username = allUsernames[key];
+
+                if (!username) {
+                    // Check if we already assigned a number to this unknown user
+                    if (!unknownUserMap.has(key)) {
+                        unknownUserMap.set(key, `Unknown ${unknownCounter}`);
+                        unknownCounter++;
+                    }
+                    username = unknownUserMap.get(key)!;
+                }
+
+                if (!entries) {
                     continue;
                 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -335,6 +335,19 @@ export function SecondsToString(
     return `${daysPart}${hours}h ${minutes}m ${seconds}s`;
 }
 
+/**
+ * Checks if the cooldown is within the next hour.
+ * @param cooldown The cooldown string in a specific bot-related format (xxHyyM) (e.g., "01h30m").
+ * @returns True if the cooldown is within the next hour, false otherwise.
+ */
+export function withinNextHour(cooldown: string): boolean {
+    cooldown.slice(1);
+
+    const num = Number(cooldown.slice(0, 2));
+
+    return num < 1;
+}
+
 export function mapTierToRarity(
     rarity: number,
     set: number,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -354,13 +354,21 @@ export function mapTierToRarity(
         return `E${set}`;
     } else if (rarity === 4) {
         return `L${set}`;
+    } else if (rarity === 5) {
+        return `M${set}`;
     }
 
     if (!loops) {
-        return `L${set}`;
+        return `M${set}`;
     }
 
-    return `L${set} :recycle:${rarity - 4}`;
+    // For rarity 6+, alternate between L and M
+    // rarity 6 -> L, rarity 7 -> M, rarity 8 -> L, etc.
+    const recycleCount = Math.floor((rarity - 4) / 2);
+    const isEvenRecycle = (rarity - 6) % 2 === 0;
+    const rarityLetter = isEvenRecycle ? "L" : "M";
+
+    return `${rarityLetter}${set} :recycle:${recycleCount}`;
 }
 
 export function isValidUUIDv4(uuid: string): boolean {

--- a/src/models/enums/Rarity.ts
+++ b/src/models/enums/Rarity.ts
@@ -4,4 +4,5 @@ export enum Rarity {
     RARE = "Rare",
     EPIC = "Epic",
     LEGENDARY = "Legendary",
+    MYTHIC = "Mythic",
 }

--- a/src/test/utilsSuite.test.ts
+++ b/src/test/utilsSuite.test.ts
@@ -224,6 +224,10 @@ describe("utilsSuite - Algebra", () => {
         expect(mapTierToRarity(1, 1)).toBe("U1");
         expect(mapTierToRarity(2, 1)).toBe("R1");
         expect(mapTierToRarity(3, 1)).toBe("E1");
+        expect(mapTierToRarity(4, 1)).toBe("L1");
+        expect(mapTierToRarity(5, 1)).toBe("M1");
+        expect(mapTierToRarity(6, 1)).toBe("L1 :recycle:1");
+        expect(mapTierToRarity(7, 1)).toBe("M1 :recycle:1");
         expect(() => mapTierToRarity(-1, 1)).toThrow("Tier cannot be negative");
     });
 

--- a/src/test/utilsSuite.test.ts
+++ b/src/test/utilsSuite.test.ts
@@ -21,6 +21,7 @@ import {
     rankToElement,
     rankToTier,
     shortenNumber,
+    withinNextHour,
 } from "@/lib/utils";
 import { MetaTeams } from "@/models/enums/MetaTeams";
 import type { GuildRaidResult } from "@/models/types";
@@ -413,5 +414,16 @@ describe("utilsSuite - Algebra", () => {
         expect(shortenNumber(2500000)).toBe("2.5M");
         expect(shortenNumber(1000000000)).toBe("1.0B");
         expect(shortenNumber(15000000000)).toBe("15.0B");
+    });
+
+    test("withinNextHour - Should return true for cooldowns within the next hour", () => {
+        expect(withinNextHour("00h30m")).toBe(true);
+        expect(withinNextHour("00h32m")).toBe(true);
+        expect(withinNextHour("00h00m")).toBe(true);
+    });
+
+    test("withinNextHour - Should return false for cooldowns outside the next hour", () => {
+        expect(withinNextHour("01h01m")).toBe(false);
+        expect(withinNextHour("02h00m")).toBe(false);
     });
 });


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the Discord bot's guild raid and management commands, focusing on improved user experience and data accuracy. The most significant changes are the addition of new rarity and rank options for commands, a new `/available-bombs` command, improved handling and display of unknown users in raid statistics, and refinements to bomb counting logic.

**New Features and Command Improvements**

* Added a new `/available-bombs` command (`src/commands/guild-raid/availableBombs.ts`) that provides a detailed, formatted overview of which guild members have bombs available, including options to view players with bombs ready within the next hour.
* Extended rarity choices in all relevant raid commands to include "Mythic" as a selectable option, ensuring more comprehensive filtering and reporting for boss rarity. [[1]](diffhunk://#diff-7df861fce50ba857567744187f641e749c0ffea979b8f5535bd4b834967a5ecfR30) [[2]](diffhunk://#diff-ba7a67e35ac9998c56527ef9fd5e15ea5dd47e1d72365b788341fbbfb5041de8R42) [[3]](diffhunk://#diff-0746e6062101e01c6354fc6bf97c58ef29b8332a5c3e2d4c307b6f42c7ed16b5R39) [[4]](diffhunk://#diff-6bb839008e4b5c05a582cebe91b3aed720c2990118a4afc7233dc139959de415R30) [[5]](diffhunk://#diff-3c049c1f4e1fe5a3a33bf6dd65373e6685506e7f2863ca122f5df23e668ead8aR23) [[6]](diffhunk://#diff-f5d31196b2bd2f818dad194270fae224c789700a7c463aaf61d581ca350b2a0aR35) [[7]](diffhunk://#diff-5f27bb9cd027fc65c4502bb9b9a0313a67773f5cb284e4637a17ee04066453a3R33) [[8]](diffhunk://#diff-0b5e8a60ea9130a1a4c13d9885bd6b7a6a4b4446377a0b27c8678279084a2f82R36) [[9]](diffhunk://#diff-973401a95c5635438c4e3c3bc1074daed9c229f2d7a74078b3f2f5d694f9551eR34) [[10]](diffhunk://#diff-7c198969595959d8d7edf3adaddc504c1ed6ae5819ce6c434ba63c95fcc322d2R33)
* Added "Adamantium" as a new rank choice in the `getMetaComps` command, expanding the available rank options for team composition queries.

**User Data and Display Enhancements**

* Improved handling of unknown user IDs in raid statistics and bomb counting: unknown users are now consistently assigned unique labels like "Unknown 1", "Unknown 2", etc., instead of a generic "Unknown", making tracking and debugging easier. This change is applied across all relevant methods in `GuildService`. [[1]](diffhunk://#diff-367f499f4273ff233fddc6cb4631abfe25fafd74be1a59308aee9e73ede49adaR419-R421) [[2]](diffhunk://#diff-367f499f4273ff233fddc6cb4631abfe25fafd74be1a59308aee9e73ede49adaL432-R447) [[3]](diffhunk://#diff-367f499f4273ff233fddc6cb4631abfe25fafd74be1a59308aee9e73ede49adaR541-R543) [[4]](diffhunk://#diff-367f499f4273ff233fddc6cb4631abfe25fafd74be1a59308aee9e73ede49adaL539-R570) [[5]](diffhunk://#diff-367f499f4273ff233fddc6cb4631abfe25fafd74be1a59308aee9e73ede49adaR678-R695) [[6]](diffhunk://#diff-367f499f4273ff233fddc6cb4631abfe25fafd74be1a59308aee9e73ede49adaR885-R903)
* Enhanced the `trackMember` command to display each user's maximum damage per boss, providing more granular performance insights in the output table. [[1]](diffhunk://#diff-7c198969595959d8d7edf3adaddc504c1ed6ae5819ce6c434ba63c95fcc322d2L269-R293) [[2]](diffhunk://#diff-7c198969595959d8d7edf3adaddc504c1ed6ae5819ce6c434ba63c95fcc322d2L297-R315)

**Logic and Calculation Adjustments**

* Updated bomb counting logic in both `/available-bombs` and `guildRaidAvailability` commands to cap the maximum displayed bombs at 30, ensuring more accurate and consistent reporting. [[1]](diffhunk://#diff-30b09038b513c57cdaee63e5e7a415f6d9817ffe356d68c6bee757ab136957b7L90-R93) [[2]](diffhunk://#diff-6b00034b77ef4779b57bb345474dc4ba478a5bc6162cf78f66f36b8bdc72e732R1-R177)

**Version Update**

* Bumped the package version in `package.json` from `0.31.2` to `0.32.0` to reflect these new features and improvements.