### PR TITLE
[0.33.0] API bug workaround 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - -->
 
+## [0.33.0] - 2025-09-07
+
+The mythic update brought tons of cool stuff to the game, but also upset the machine spirit of the API slightly that affected data at, and after, the mythic tier. This update brings a workaround to these issues until Snowprint has time to fix the issue on their side. Special thanks to Tani for testing the workaround during development.
+
+### Added
+
+-   Data from the API is now pre-processed if the guild has reached the first mythic boss of the season. The preprocessing corrects the tier, set, and rarity of the bosses so that it shows up correctly, with the right looping values, in all commands.
+
 ## [0.32.2] - 2025-08-26
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "0.32.2",
+    "version": "0.33.0",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/client/HominaTacticusClient.ts
+++ b/src/client/HominaTacticusClient.ts
@@ -35,10 +35,6 @@ class HominaTacticusClient {
                 continue;
             }
 
-            console.log(
-                `${raid.type} - ${raid.maxHp} - ${raid.tier} - ${raid.set}`
-            );
-
             // Find the mythic boss
             if (
                 raid.maxHp > 20e6 ||

--- a/src/client/HominaTacticusClient.ts
+++ b/src/client/HominaTacticusClient.ts
@@ -24,6 +24,13 @@ class HominaTacticusClient {
         let currentSet = 0;
         let currentType = "";
         let previousMythic = false;
+
+        // No need to process if the guild has not reached tier 5 raids yet
+        const lastTier = raids.at(-1)?.tier;
+        if (!lastTier || lastTier < 5) {
+            return raids;
+        }
+
         for (const raid of raids) {
             if (raid.tier < 5) {
                 continue;
@@ -40,11 +47,11 @@ class HominaTacticusClient {
             ) {
                 if (!previousMythic) console.log("Mythic found");
                 raid.rarity = Rarity.MYTHIC;
+                if (!previousMythic && raid.tier >= 6) {
+                    currentTier++;
+                }
                 previousMythic = true;
                 currentSet = 0;
-                if (raid.tier >= 6) {
-                    currentTier = raid.tier + 1;
-                }
             }
 
             // Find the first legendary boss after a mythic boss

--- a/src/client/HominaTacticusClient.ts
+++ b/src/client/HominaTacticusClient.ts
@@ -1,4 +1,3 @@
-import { mapTierToRarity } from "@/lib/utils";
 import { Rarity } from "@/models/enums";
 import type { Player, Raid } from "@/models/types";
 import type { Guild } from "@/models/types/Guild";
@@ -20,10 +19,10 @@ class HominaTacticusClient {
     private baseUrl: string = "https://api.tacticusgame.com/api/v1";
 
     preProcessData(raids: Raid[]): Raid[] {
-        let currentTier = 5;
-        let currentSet = 0;
-        let currentType = "";
-        let previousMythic = false;
+        let currentTier: number = 5;
+        let currentSet: number = 0;
+        let currentType: string = "";
+        let previousMythic: boolean = false;
 
         // No need to process if the guild has not reached tier 5 raids yet
         const lastTier = raids.at(-1)?.tier;
@@ -45,7 +44,6 @@ class HominaTacticusClient {
                 raid.maxHp > 20e6 ||
                 (raid.encounterIndex > 0 && raid.maxHp > 1.9e6)
             ) {
-                if (!previousMythic) console.log("Mythic found");
                 raid.rarity = Rarity.MYTHIC;
                 if (!previousMythic && raid.tier >= 6) {
                     currentTier++;
@@ -60,7 +58,6 @@ class HominaTacticusClient {
                 (raid.maxHp < 20e6 ||
                     (raid.encounterIndex > 0 && raid.maxHp < 1.9e6))
             ) {
-                console.log("First legendary found");
                 previousMythic = false;
                 currentTier++;
                 currentSet = 0;
@@ -72,22 +69,12 @@ class HominaTacticusClient {
                 (raid.maxHp < 20e6 ||
                     (raid.encounterIndex > 0 && raid.maxHp < 1.9e6))
             ) {
-                console.log("Other legendary found");
                 currentSet = raid.set;
             }
 
-            const prevType = currentType;
             currentType = raid.type;
             raid.tier = currentTier;
             raid.set = currentSet;
-
-            if (prevType !== currentType) {
-                console.log(
-                    `New: ${mapTierToRarity(raid.tier, raid.set, true)} ${
-                        raid.type
-                    } - ${raid.maxHp} - ${raid.tier} - ${raid.set}`
-                );
-            }
         }
 
         return raids;


### PR DESCRIPTION
This pull request introduces a workaround to address data inconsistencies from the API affecting raids at and after the mythic tier. The main change is the addition of a preprocessing step that corrects the tier, set, and rarity of bosses for guilds that have reached the first mythic boss of the season. This ensures that raid data is displayed correctly across all commands. The version is also bumped to 0.33.0.

**Mythic tier data correction:**

* Added a `preProcessData` method to `HominaTacticusClient` that adjusts the tier, set, and rarity for raids at and after the mythic tier to correct API inconsistencies. This method is now called in both `getGuildRaids` and `getGuildRaidsById` to ensure consistent data processing. [[1]](diffhunk://#diff-98831ad8219d1c532dd9e5d8105efb7d60d098efe2ff1d085e1b33e12a010935R21-R82) [[2]](diffhunk://#diff-98831ad8219d1c532dd9e5d8105efb7d60d098efe2ff1d085e1b33e12a010935R171-R172) [[3]](diffhunk://#diff-98831ad8219d1c532dd9e5d8105efb7d60d098efe2ff1d085e1b33e12a010935R194-R195)

**Version update and documentation:**

* Updated `package.json` to version 0.33.0.
* Added a changelog entry describing the mythic update workaround and its purpose.