### PR TITLE
Hotfix for /season-highscore usernames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - -->
 
+## [0.34.1] - 2025-09-21
+
+### Fixed
+
+-   `/season-highscore` no longer displays all names as 'unknown'.
+
 ## [0.34.0] - 2025-09-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "0.34.0",
+    "version": "0.34.1",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/commands/guild-raid/seasonHighscore.ts
+++ b/src/commands/guild-raid/seasonHighscore.ts
@@ -81,12 +81,24 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
         const csvService = new CsvService();
 
-        const csvBuffer = await csvService.createHighscores(highscores);
+        const guildId = await service.getGuildId(discordId);
+        if (!guildId) {
+            await interaction.editReply({
+                content: "Could not find the guild ID for your account",
+            });
+            return;
+        }
+
+        const csvBuffer = await csvService.createHighscores(
+            highscores,
+            guildId
+        );
 
         const chartService = new ChartService();
 
         const chartBuffer = await chartService.createHighscoreChart(
             highscores,
+            guildId,
             `Season ${season} Highscores (${rarity})`
         );
 

--- a/src/lib/services/ChartService.ts
+++ b/src/lib/services/ChartService.ts
@@ -752,6 +752,7 @@ export class ChartService {
 
     async createHighscoreChart(
         data: Record<string, Highscore[]>,
+        guildId: string,
         title: string
     ) {
         const allUsernames = new Set<string>();
@@ -765,7 +766,7 @@ export class ChartService {
 
         const userIds = Array.from(allUsernames);
 
-        const usernames = await dbController.getPlayerNames(userIds);
+        const usernames = await dbController.getPlayerNames(userIds, guildId);
         const labels = userIds.map((id) => usernames[id] || "Unknown");
         const datasets = Object.entries(data).map(
             ([boss, highscores], colorIndex) => {

--- a/src/lib/services/CsvService.ts
+++ b/src/lib/services/CsvService.ts
@@ -27,7 +27,10 @@ export class CsvService {
         return buffer;
     }
 
-    async createHighscores(highscores: Record<string, Highscore[]>) {
+    async createHighscores(
+        highscores: Record<string, Highscore[]>,
+        guildId: string
+    ) {
         let output = "";
 
         const allUsernames = new Set<string>();
@@ -38,7 +41,7 @@ export class CsvService {
         }
 
         const userIds = Array.from(allUsernames);
-        const usernames = await dbController.getPlayerNames(userIds);
+        const usernames = await dbController.getPlayerNames(userIds, guildId);
 
         for (const [boss, scores] of Object.entries(highscores)) {
             output += `Boss: ${boss}\n`;


### PR DESCRIPTION
This pull request addresses a bug where the `/season-highscore` command was displaying all names as 'unknown'. The fix ensures that player names are correctly retrieved and displayed by passing the `guildId` to the relevant services, which allows for accurate username resolution within the context of a specific guild. Additionally, the version is bumped to `0.34.1` and the changelog is updated accordingly.

**Bug Fixes:**

* Fixed `/season-highscore` so that player names are now correctly displayed instead of 'unknown' by ensuring the `guildId` is retrieved and passed to both `CsvService` and `ChartService` for username resolution. [[1]](diffhunk://#diff-5f27bb9cd027fc65c4502bb9b9a0313a67773f5cb284e4637a17ee04066453a3L84-R101) [[2]](diffhunk://#diff-ed7e99ada8988a6a5c92bafb02808643363ebc7853e996f36664dae1f2b533ddL30-R33) [[3]](diffhunk://#diff-ed7e99ada8988a6a5c92bafb02808643363ebc7853e996f36664dae1f2b533ddL41-R44) [[4]](diffhunk://#diff-bbfb5439597dbfd7db536a6ce84379f4b9c0dacfd916f07ecb7470f7192bf0ebR755) [[5]](diffhunk://#diff-bbfb5439597dbfd7db536a6ce84379f4b9c0dacfd916f07ecb7470f7192bf0ebL768-R769)

**Documentation and Versioning:**

* Updated `CHANGELOG.md` to document the bug fix in version `0.34.1`.
* Bumped version in `package.json` from `0.34.0` to `0.34.1`.