### PR TITLE
Add tokens-per-loop command and enhance token calculation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - -->
 
+## [1.14.0]
+
+### Added
+
+- **New command!** - `/tokens-per-loop` - See how many tokens your guild spent on each loop in a given season as a line chart.
+  - Includes a linear regression trendline (fitted on completed loops only) with a percentage change indicator.
+  - Option: `season` — the season to inspect. Defaults to the current season.
+
 ## [1.13.1]
 
 I will never hide the fact that I despise Apple and the air their executives breathe.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "1.13.1",
+    "version": "1.14.0",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/commands/guild-raid/tokensPerLoop.ts
+++ b/src/commands/guild-raid/tokensPerLoop.ts
@@ -1,0 +1,114 @@
+import { logger } from "@/lib";
+import {
+    getCurrentSeason,
+    MINIMUM_SEASON_THRESHOLD,
+} from "@/lib/configs/constants";
+import { ChartService } from "@/lib/services/ChartService";
+import { GuildService } from "@/lib/services/GuildService.ts";
+import { isInvalidSeason } from "@/lib/utils/timeUtils";
+import {
+    AttachmentBuilder,
+    ChatInputCommandInteraction,
+    EmbedBuilder,
+    SlashCommandBuilder,
+} from "discord.js";
+
+export const cooldown = 5;
+
+export const data = new SlashCommandBuilder()
+    .setName("tokens-per-loop")
+    .setDescription(
+        "Show how many tokens the guild spent on each loop in a given season",
+    )
+    .addNumberOption((option) =>
+        option
+            .setName("season")
+            .setDescription("The season to check (defaults to current season)")
+            .setRequired(false)
+            .setMinValue(MINIMUM_SEASON_THRESHOLD),
+    );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+    await interaction.deferReply();
+
+    const providedSeason = interaction.options.getNumber("season");
+    const season = providedSeason ?? getCurrentSeason();
+    const discordId = interaction.user.id;
+
+    if (providedSeason !== null && isInvalidSeason(providedSeason)) {
+        await interaction.editReply({
+            content: `Please provide a valid season number greater than or equal to ${MINIMUM_SEASON_THRESHOLD}. The current season is ${getCurrentSeason()}`,
+        });
+        return;
+    }
+
+    const service = new GuildService();
+
+    logger.info(
+        `${interaction.user.username} attempting to use /tokens-per-loop for season ${season}`,
+    );
+
+    try {
+        const tokensPerLoop = await service.getTokensPerLoopBySeason(
+            discordId,
+            season,
+        );
+
+        if (!tokensPerLoop || Object.keys(tokensPerLoop).length === 0) {
+            await interaction.editReply({
+                content: `No data found for season ${season}. Please make sure you have registered your API-token.`,
+            });
+            return;
+        }
+
+        const loopNumbers = Object.keys(tokensPerLoop)
+            .map(Number)
+            .sort((a, b) => a - b);
+
+        const loopLabels = loopNumbers.map((n) => `Loop ${n}`);
+        const tokenValues = loopNumbers.map((n) => tokensPerLoop[n] ?? 0);
+
+        const chartService = new ChartService();
+        const chartBuffer = await chartService.createSeasonalTrendChart(
+            tokenValues,
+            loopLabels,
+            `Tokens spent per loop — Season ${season}`,
+            {
+                seriesLabel: "Tokens used",
+                yAxisLabel: "Tokens used",
+                integerTicks: true,
+            },
+        );
+
+        const attachment = new AttachmentBuilder(chartBuffer, {
+            name: "tokens-per-loop.png",
+        });
+
+        const embed = new EmbedBuilder()
+            .setColor("#0099ff")
+            .setTitle(`Tokens spent per loop — Season ${season}`)
+            .setDescription(
+                `Total guild tokens spent on each loop in season **${season}** (${loopNumbers.length} loop${loopNumbers.length !== 1 ? "s" : ""} found).\n` +
+                    "- Each non-bomb attack costs one token.\n" +
+                    "- A loop corresponds to one full pass through the boss roster.\n",
+            )
+            .setImage("attachment://tokens-per-loop.png")
+            .setTimestamp()
+            .setFooter({
+                text: "Referral code: HUG-44-CAN if you want to support the bot development",
+            });
+
+        await interaction.editReply({ embeds: [embed], files: [attachment] });
+
+        logger.info(
+            `${interaction.user.username} successfully used /tokens-per-loop for season ${season}`,
+        );
+    } catch (error) {
+        logger.error(error, "Error occurred in tokens-per-loop: ");
+        await interaction.editReply({
+            content:
+                "An error occurred while generating the tokens per loop chart.",
+        });
+        return;
+    }
+}

--- a/src/commands/guild-raid/tokensPerLoop.ts
+++ b/src/commands/guild-raid/tokensPerLoop.ts
@@ -5,6 +5,7 @@ import {
 } from "@/lib/configs/constants";
 import { ChartService } from "@/lib/services/ChartService";
 import { GuildService } from "@/lib/services/GuildService.ts";
+import { linearRegression } from "@/lib/utils/mathUtils";
 import { isInvalidSeason } from "@/lib/utils/timeUtils";
 import {
     AttachmentBuilder,
@@ -68,6 +69,23 @@ export async function execute(interaction: ChatInputCommandInteraction) {
         const loopLabels = loopNumbers.map((n) => `Loop ${n}`);
         const tokenValues = loopNumbers.map((n) => tokensPerLoop[n] ?? 0);
 
+        // Exclude the last loop (potentially in-progress) from the regression
+        // fit, but still extrapolate the trendline across all plotted points.
+        const fitValues = tokenValues.slice(0, -1);
+        const trendline =
+            fitValues.length >= 2
+                ? linearRegression(fitValues, tokenValues.length)
+                : undefined;
+
+        let trendPct: string | undefined;
+        if (trendline && trendline[0]! !== 0) {
+            const change =
+                ((trendline[trendline.length - 1]! - trendline[0]!) /
+                    trendline[0]!) *
+                100;
+            trendPct = `${change >= 0 ? "+" : ""}${change.toFixed(1)}%`;
+        }
+
         const chartService = new ChartService();
         const chartBuffer = await chartService.createSeasonalTrendChart(
             tokenValues,
@@ -77,6 +95,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                 seriesLabel: "Tokens used",
                 yAxisLabel: "Tokens used",
                 integerTicks: true,
+                trendline,
             },
         );
 
@@ -90,7 +109,14 @@ export async function execute(interaction: ChatInputCommandInteraction) {
             .setDescription(
                 `Total guild tokens spent on each loop in season **${season}** (${loopNumbers.length} loop${loopNumbers.length !== 1 ? "s" : ""} found).\n` +
                     "- Each non-bomb attack costs one token.\n" +
-                    "- A loop corresponds to one full pass through the boss roster.\n",
+                    "- A loop is completed each time the cap boss is defeated.\n" +
+                    (trendline !== undefined
+                        ? `- **Trend:** ${
+                              trendline[trendline.length - 1]! >= trendline[0]!
+                                  ? "↗️ increasing"
+                                  : "↘️ decreasing"
+                          }${trendPct ? ` (${trendPct})` : ""} (linear regression)\n`
+                        : ""),
             )
             .setImage("attachment://tokens-per-loop.png")
             .setTimestamp()

--- a/src/lib/services/GuildService.ts
+++ b/src/lib/services/GuildService.ts
@@ -1984,4 +1984,43 @@ export class GuildService {
             return null;
         }
     }
+
+    /**
+     * Calculates the number of tokens spent per loop for a single season.
+     * Each non-bomb raid entry costs one token; entries are grouped by their
+     * `tier` value, which corresponds to the loop number within the season.
+     * @param discordId The Discord user ID to retrieve the API key for.
+     * @param season The season number to analyse.
+     * @returns A record mapping loop number (tier) to tokens used, or null on error.
+     */
+    async getTokensPerLoopBySeason(
+        discordId: string,
+        season: number,
+    ): Promise<Record<number, number> | null> {
+        try {
+            const apiKey = await dbController.getUserToken(discordId);
+            if (!apiKey) {
+                logger.error("No API key found for user:", discordId);
+                return null;
+            }
+
+            const resp = await this.client.getGuildRaidBySeason(apiKey, season);
+            if (!resp || !resp.entries) {
+                return null;
+            }
+
+            const result: Record<number, number> = {};
+            for (const entry of resp.entries) {
+                if (entry.damageType === DamageType.BOMB) {
+                    continue;
+                }
+                result[entry.tier] = (result[entry.tier] ?? 0) + 1;
+            }
+
+            return result;
+        } catch (error) {
+            logger.error(error, "Error fetching tokens per loop by season: ");
+            return null;
+        }
+    }
 }

--- a/src/lib/services/GuildService.ts
+++ b/src/lib/services/GuildService.ts
@@ -1986,12 +1986,15 @@ export class GuildService {
     }
 
     /**
-     * Calculates the number of tokens spent per loop for a single season.
-     * Each non-bomb raid entry costs one token; entries are grouped by their
-     * `tier` value, which corresponds to the loop number within the season.
+     * Calculates the number of tokens spent per completed loop for a single
+     * season.  A loop is defined the same way as in
+     * {@link getLoopsCompletedInLastSeasons}: the cap boss (highest
+     * rarity + set pair) being defeated marks the end of a loop.  Every
+     * non-bomb raid entry costs one token; entries are bucketed into loops
+     * based on the tier ranges delimited by cap-boss kills.
      * @param discordId The Discord user ID to retrieve the API key for.
      * @param season The season number to analyse.
-     * @returns A record mapping loop number (tier) to tokens used, or null on error.
+     * @returns A record mapping 1-based loop number to tokens used, or null on error.
      */
     async getTokensPerLoopBySeason(
         discordId: string,
@@ -2009,12 +2012,61 @@ export class GuildService {
                 return null;
             }
 
+            // ── Determine the cap boss (same logic as getLoopsCompletedInLastSeasons) ──
+            const bossEntries = resp.entries.filter(
+                (e) => e.encounterType === EncounterType.BOSS,
+            );
+
+            if (bossEntries.length === 0) {
+                return null;
+            }
+
+            const rarityRank = (r: Rarity): number =>
+                Object.values(Rarity).indexOf(r);
+
+            let capRarity: Rarity = bossEntries[0]!.rarity;
+            let capSet: number = bossEntries[0]!.set;
+            for (const entry of bossEntries) {
+                const entryRank = rarityRank(entry.rarity);
+                const capRank = rarityRank(capRarity);
+                if (
+                    entryRank > capRank ||
+                    (entryRank === capRank && entry.set > capSet)
+                ) {
+                    capRarity = entry.rarity;
+                    capSet = entry.set;
+                }
+            }
+
+            // ── Find the tier values where a cap boss was killed ──
+            const completedTiers = new Set<number>();
+            for (const entry of bossEntries) {
+                if (
+                    entry.rarity === capRarity &&
+                    entry.set === capSet &&
+                    entry.remainingHp === 0
+                ) {
+                    completedTiers.add(entry.tier);
+                }
+            }
+            const sortedCapTiers = [...completedTiers].sort((a, b) => a - b);
+
+            // ── Bucket every non-bomb entry into a loop ──
             const result: Record<number, number> = {};
             for (const entry of resp.entries) {
                 if (entry.damageType === DamageType.BOMB) {
                     continue;
                 }
-                result[entry.tier] = (result[entry.tier] ?? 0) + 1;
+                // Find the first cap-kill tier >= this entry's tier
+                let loopIndex = sortedCapTiers.findIndex(
+                    (t) => entry.tier <= t,
+                );
+                if (loopIndex === -1) {
+                    // Beyond the last completed loop → current in-progress loop
+                    loopIndex = sortedCapTiers.length;
+                }
+                const loopNumber = loopIndex + 1;
+                result[loopNumber] = (result[loopNumber] ?? 0) + 1;
             }
 
             return result;


### PR DESCRIPTION
This pull request introduces a new `/tokens-per-loop` Discord slash command, allowing users to visualize the number of tokens their guild spent on each completed loop in a given season. The main changes include the implementation of the command handler, the addition of a service method to calculate tokens per loop, and integration with chart generation and error handling.

**New `/tokens-per-loop` command and supporting logic:**

* Added a new command handler `tokensPerLoop.ts` that provides a `/tokens-per-loop` slash command. This command generates a chart of tokens spent per loop in a selected season, with trendline analysis and detailed user feedback.
* Implemented `getTokensPerLoopBySeason` in `GuildService`, which calculates the number of tokens spent per completed loop for a specific season by identifying cap boss kills and bucketing raid entries accordingly.

**Service integration and user experience:**

* Integrated the new command with `GuildService`, `ChartService`, and utility functions for season validation, chart creation, and trendline calculation.
* Added comprehensive error handling and user messaging for missing data, invalid input, and API errors, ensuring robust interaction feedback.