### PR TITLE
Fix/auto complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Today Homina celebrates reaching the milestone of 200+ registered guilds—or 6 
   - Optional parameter: `season` — defaults to the current season.
   - Time calculation now uses `completedOn` of the last attack minus `startedOn` of the first for more accurate kill durations.
 
+### Fixed
+
+- Fixed a bug where the auto-complete options like found in `/track-member` fails. The bug was caused by discord's 3-second timeout for auto-completion and ocassionaly slow fetching of usernames from the game. Usernames are now cached to help alleviate this issue. In some cases the auto-complete might fail if you haven't used another command first, but running it a second time or running another command will solve it.
+
 ## [1.18.0]
 
 Today I've got another feature update for you all. Special thanks to the beta-testers for the assist on this one!

--- a/src/client/MiddlewareClient.ts
+++ b/src/client/MiddlewareClient.ts
@@ -9,6 +9,13 @@ import { ExternalApiError } from "@/models/errors/ServiceError";
 const MIDDLEWARE_URL = process.env.MIDDLEWARE_URL ?? "http://localhost:3001";
 const MIDDLEWARE_TIMEOUT = 30000;
 
+const GUILD_MEMBERS_CACHE_TTL = 60_000; // 1 minute
+const GUILD_MEMBERS_STALE_TTL = 300_000; // 5 minutes - serve stale while refreshing
+const guildMembersCache = new Map<
+    string,
+    { members: MiddlewareMember[]; expiresAt: number; staleAt: number }
+>();
+
 type MiddlewareResponse = {
     success: boolean;
     members?: MiddlewareMember[];
@@ -22,6 +29,25 @@ type MiddlewareResponse = {
  * @returns Array of guild members with userId and displayName
  */
 export async function fetchGuildMembers(
+    guildId: string,
+): Promise<MiddlewareMember[]> {
+    const cached = guildMembersCache.get(guildId);
+    const now = Date.now();
+
+    if (cached && cached.expiresAt > now) {
+        return cached.members;
+    }
+
+    // Stale-while-revalidate: return stale data immediately, refresh in background
+    if (cached && cached.staleAt > now) {
+        refreshGuildMembersCache(guildId);
+        return cached.members;
+    }
+
+    return await refreshGuildMembersCache(guildId);
+}
+
+async function refreshGuildMembersCache(
     guildId: string,
 ): Promise<MiddlewareMember[]> {
     const controller = new AbortController();
@@ -38,24 +64,39 @@ export async function fetchGuildMembers(
         clearTimeout(timeoutId);
 
         if (!response.ok) {
-            throw new ExternalApiError("Middleware guild members request failed", {
-                context: { guildId, status: response.status },
-            });
+            throw new ExternalApiError(
+                "Middleware guild members request failed",
+                {
+                    context: { guildId, status: response.status },
+                },
+            );
         }
 
         const data = (await response.json()) as MiddlewareResponse;
         if (!data.success) {
-            throw new ExternalApiError("Middleware returned unsuccessful response", {
-                context: { guildId, error: data.error },
-            });
+            throw new ExternalApiError(
+                "Middleware returned unsuccessful response",
+                {
+                    context: { guildId, error: data.error },
+                },
+            );
         }
-        return data.members ?? [];
+        const members = data.members ?? [];
+        guildMembersCache.set(guildId, {
+            members,
+            expiresAt: Date.now() + GUILD_MEMBERS_CACHE_TTL,
+            staleAt: Date.now() + GUILD_MEMBERS_STALE_TTL,
+        });
+        return members;
     } catch (error) {
         clearTimeout(timeoutId);
         if (error instanceof ExternalApiError) throw error;
-        throw new ExternalApiError("Failed to fetch guild members via middleware", {
-            cause: error,
-            context: { guildId },
-        });
+        throw new ExternalApiError(
+            "Failed to fetch guild members via middleware",
+            {
+                cause: error,
+                context: { guildId },
+            },
+        );
     }
 }

--- a/src/commands/guild-raid/tokenHistory.ts
+++ b/src/commands/guild-raid/tokenHistory.ts
@@ -57,16 +57,17 @@ export async function autocomplete(interaction: AutocompleteInteraction) {
     try {
         const service = new GuildService();
         const guildId = await service.getGuildId(discordId);
-        const members = await fetchGuildMembers(guildId);
+
+        const [members, metadata] = await Promise.all([
+            fetchGuildMembers(guildId),
+            dbController.getAllPlayerMetadataByGuild(guildId, false),
+        ]);
+
         if (members.length === 0) {
             await interaction.respond([]);
             return;
         }
 
-        const metadata = await dbController.getAllPlayerMetadataByGuild(
-            guildId,
-            false,
-        );
         const nicknameMap = new Map<string, string>();
         for (const entry of metadata) {
             if (entry.nickname) {
@@ -92,8 +93,9 @@ export async function autocomplete(interaction: AutocompleteInteraction) {
             })),
         );
     } catch (error) {
+        if ((error as any)?.code === 10062) return;
         logger.error(error, "Error in token-history autocomplete");
-        await interaction.respond([]);
+        await interaction.respond([]).catch(() => {});
     }
 }
 

--- a/src/commands/guild-raid/trackMember.ts
+++ b/src/commands/guild-raid/trackMember.ts
@@ -85,16 +85,17 @@ export async function autocomplete(interaction: AutocompleteInteraction) {
     try {
         const service = new GuildService();
         const guildId = await service.getGuildId(discordId);
-        const members = await fetchGuildMembers(guildId);
+
+        const [members, metadata] = await Promise.all([
+            fetchGuildMembers(guildId),
+            dbController.getAllPlayerMetadataByGuild(guildId, false),
+        ]);
+
         if (members.length === 0) {
             await interaction.respond([]);
             return;
         }
 
-        const metadata = await dbController.getAllPlayerMetadataByGuild(
-            guildId,
-            false,
-        );
         const nicknameMap = new Map<string, string>();
         for (const entry of metadata) {
             if (entry.nickname) {
@@ -120,8 +121,9 @@ export async function autocomplete(interaction: AutocompleteInteraction) {
             })),
         );
     } catch (error) {
+        if ((error as any)?.code === 10062) return;
         logger.error(error, "Error in track-member autocomplete");
-        await interaction.respond([]);
+        await interaction.respond([]).catch(() => {});
     }
 }
 

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -24,8 +24,9 @@ export async function execute(interaction: Interaction) {
         try {
             await command.autocomplete(interaction);
         } catch (error) {
+            if ((error as any)?.code === 10062) return;
             logger.error(error, "Error handling autocomplete");
-            await interaction.respond([]);
+            await interaction.respond([]).catch(() => {});
         }
         return;
     }


### PR DESCRIPTION
This pull request introduces a caching mechanism for guild member fetches from the middleware API to improve performance and reduce redundant requests. It also optimizes how autocomplete handlers fetch members and metadata, and adds improved error handling to prevent unnecessary error responses for specific Discord error codes.

**Caching and performance improvements:**

* Added an in-memory cache (`guildMembersCache`) to `fetchGuildMembers` in `MiddlewareClient.ts`, implementing a stale-while-revalidate strategy with configurable TTLs to reduce redundant API calls and improve response times. [[1]](diffhunk://#diff-c781d995a6d06ad47c3bd6d1903472344fbad549b107eaf339421256d5e553cbR12-R18) [[2]](diffhunk://#diff-c781d995a6d06ad47c3bd6d1903472344fbad549b107eaf339421256d5e553cbR33-R51) [[3]](diffhunk://#diff-c781d995a6d06ad47c3bd6d1903472344fbad549b107eaf339421256d5e553cbL41-R100)

**Autocomplete handler optimizations:**

* Refactored `autocomplete` handlers in `tokenHistory.ts` and `trackMember.ts` to fetch guild members and player metadata in parallel using `Promise.all`, reducing latency for autocomplete suggestions. [[1]](diffhunk://#diff-30f38f881e8a694217943bcca1865ceb2fe2c46ee454da7fef6c6d5adf8de3d6L60-L69) [[2]](diffhunk://#diff-7c198969595959d8d7edf3adaddc504c1ed6ae5819ce6c434ba63c95fcc322d2L88-L97)

**Error handling improvements:**

* Updated all relevant autocomplete handlers to gracefully handle Discord error code 10062 by silently returning, and to suppress unhandled promise rejections when calling `interaction.respond([])`. [[1]](diffhunk://#diff-30f38f881e8a694217943bcca1865ceb2fe2c46ee454da7fef6c6d5adf8de3d6R96-R98) [[2]](diffhunk://#diff-7c198969595959d8d7edf3adaddc504c1ed6ae5819ce6c434ba63c95fcc322d2R124-R126) [[3]](diffhunk://#diff-b0dd6aa2ffdba035534c77a5be453f80b646bb6e4cf41576d4994a003641707dR27-R29)