### PR TITLE
feat: add lavstodes team and update related configurations and logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.0]
+
+This patch updates the meta team config to better represent the current picture of the meta teams. I've also added a little raffle code you can use in the anniversary raffle over at the bottom of https://tacticusgame.com/. You can find the raffle code at the bottom of all commands or over at https://hominabot.com
+
+### Added
+
+- Added support for a new meta team: Lavstodes.
+- Added new character data required for Lavstodes team detection and reporting.
+- Added introduction of mythic 3 bosses as a game event displayed in relevant graphs
+
+### Changed
+
+- Updated meta team detection to classify Lavstodes lineups (including lynchpin-based validation).
+- Updated team distribution and damage calculations to include Lavstodes in summaries and percentages.
+- Updated charts and visual breakdowns to display Lavstodes usage and damage alongside other meta teams.
+
 ## [1.22.0]
 
 Summer vacay is over and I'm back with another update. This version aims to upgrade to the scheduling system with more commands, smarter timing, and a new way to get your end-of-season summary delivered automatically.

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "homina",

--- a/docs/site-config.js
+++ b/docs/site-config.js
@@ -4,10 +4,10 @@
 var SITE_CONFIG = {
     // Temporary code banner
     showBanner: true,
-    tempCode: "HOMINAUGUST",
-    tempNote: "Limited-time code \u2013 redeem in-game before it expires.",
+    tempCode: "AUTOMATON",
+    tempNote: "This is a raffle code for the anniversary raffle. You can support the bot by claiming the code and entering this webpage URL into the favourite content creator <3",
     // ISO date string (YYYY-MM-DD) after which the banner auto-hides. Set to null to disable expiry.
-    bannerExpiryDate: "2026-08-14"
+    bannerExpiryDate: "2026-08-31"
 };
 
 (function () {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "1.22.0",
+    "version": "1.23.0",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/lib/configs/charactersConfig.ts
+++ b/src/lib/configs/charactersConfig.ts
@@ -99,6 +99,7 @@ export const characters = {
     Arjac: { id: "spaceRockfist", name: "Arjac" },
     Njal: { id: "spaceStormcaller", name: "Njal" },
     Ulf: { id: "spaceWulfen", name: "Ulf" },
+    Baldr: { id: "spaceWolfPriest", name: "Baldr" },
 
     // Tau
     AunShi: { id: "tauAunShi", name: "Aun'Shi" },
@@ -143,6 +144,10 @@ export const characters = {
     Macer: { id: "worldJakhal", name: "Macer" },
     Kharn: { id: "worldKharn", name: "Kharn" },
     Wrask: { id: "worldTerminator", name: "Wrask" },
+
+    // Leagues of Votann
+    Vynn: { id: "votanIronmaster", name: "Vynn" },
+    Uthar: { id: "votanUthar", name: "Ûthar" },
 
     // NPCs
     Hapthatra: { id: "Hapthatra", name: "Hapthatra" },

--- a/src/lib/configs/constants.ts
+++ b/src/lib/configs/constants.ts
@@ -9,7 +9,8 @@ export const getCurrentSeason = () => calculateCurrentSeason(new Date());
 export const META_TEAM_THRESHOLD = 5;
 export const MAX_TOKENS_PER_SEASON = 28;
 
-export const STANDARD_FOOTER_TEXT = "Referral code: HUG-44-CAN";
+export const STANDARD_FOOTER_TEXT =
+    "Referral code: HUG-44-CAN | Raffle code: AUTOMATON";
 
 // Scheduled commands configuration
 export const MAX_SCHEDULES_PER_GUILD = 10;

--- a/src/lib/configs/constants.ts
+++ b/src/lib/configs/constants.ts
@@ -29,6 +29,7 @@ export const SEASON_85_SEASON_START = new Date(2025, 9, 8, 10, 0, 0);
 export const GAME_EVENTS: { season: number; label: string }[] = [
     { season: 82, label: "Mythic 1 introduced" },
     { season: 97, label: "Mythic 2 introduced" },
+    { season: 107, label: "Mythic 3 introduced" },
 ];
 
 export const BOSS_EMOJIS: Record<string, string> = {

--- a/src/lib/configs/metaTeamConfig.ts
+++ b/src/lib/configs/metaTeamConfig.ts
@@ -50,18 +50,33 @@ export const neuroTeam = [
 export const custodesTeam = [
     characters.Trajann.id,
     characters.Kariyan.id,
-    characters.Ragnar.id,
     characters.Kharn.id,
     characters.Dante.id,
-    characters.Mephiston.id,
     characters.Abaddon.id,
     characters.Helbrecht.id,
     characters.Isabella.id,
     characters.Vitruvius.id,
-    characters.Laviscus.id,
     characters.Aesoth.id,
     characters.Gulgortz.id,
     characters.Atlacoya.id,
+];
+
+export const lavstodesTeam = [
+    characters.Laviscus.id,
+    characters.Trajann.id,
+    characters.Kariyan.id,
+    characters.Kharn.id,
+    characters.Dante.id,
+    characters.Abaddon.id,
+    characters.Helbrecht.id,
+    characters.Isabella.id,
+    characters.Vitruvius.id,
+    characters.Aesoth.id,
+    characters.Gulgortz.id,
+    characters.Atlacoya.id,
+    characters.Baldr.id,
+    characters.Roswitha.id,
+    characters.Nicodemus.id,
 ];
 
 export const battlesuitTeam = [
@@ -90,4 +105,9 @@ export const lynchpinHeroes: Record<string, string[]> = {
     ],
     Neuro: [characters.Neurothrope.id],
     Custodes: [characters.Trajann.id, characters.Kariyan.id],
+    Lavstodes: [
+        characters.Laviscus.id,
+        characters.Kariyan.id,
+        characters.Trajann.id,
+    ],
 };

--- a/src/lib/services/ChartService.ts
+++ b/src/lib/services/ChartService.ts
@@ -527,11 +527,18 @@ export class ChartService {
             data.neuro = data.neuroDamage ?? 0;
             data.custodes = data.custodesDamage ?? 0;
             data.battlesuit = data.battlesuitDamage ?? 0;
+            data.lavstodes = data.lavstodesDamage ?? 0;
             data.other = data.otherDamage ?? 0;
         }
 
         const total =
-            data.mech + data.multihit + data.neuro + data.custodes + data.other;
+            data.mech +
+            data.multihit +
+            data.neuro +
+            data.custodes +
+            data.lavstodes +
+            data.battlesuit +
+            data.other;
         if (total === 0) {
             throw new Error("No data to display in the chart.");
         }
@@ -543,6 +550,7 @@ export class ChartService {
         const battlesuitPercentage = ((data.battlesuit / total) * 100).toFixed(
             1,
         );
+        const lavstodesPercentage = ((data.lavstodes / total) * 100).toFixed(1);
         const otherPercentage = ((data.other / total) * 100).toFixed(1);
 
         const chart = await canvas.renderToBuffer({
@@ -554,6 +562,7 @@ export class ChartService {
                     `Psyker (${psykerPercentage}%)`,
                     `Custodes (${custodesPercentage}%)`,
                     `Battlesuit (${battlesuitPercentage}%)`,
+                    `Lavstodes (${lavstodesPercentage}%)`,
                     `Other (${otherPercentage}%)`,
                 ],
                 datasets: [
@@ -565,6 +574,7 @@ export class ChartService {
                             data.neuro,
                             data.custodes,
                             data.battlesuit,
+                            data.lavstodes,
                             data.other,
                         ],
                         backgroundColor: [
@@ -573,6 +583,7 @@ export class ChartService {
                             CHART_COLORS.purple,
                             CHART_COLORS.orange,
                             CHART_COLORS.green,
+                            CHART_COLORS.yellow,
                             CHART_COLORS.grey,
                         ],
                     },

--- a/src/lib/services/MetaTeamService.ts
+++ b/src/lib/services/MetaTeamService.ts
@@ -53,6 +53,8 @@ export class MetaTeamService {
                 custodes: 0,
                 battlesuit: 0,
                 battlesuitDamage: 0,
+                lavstodes: 0,
+                lavstodesDamage: 0,
             };
 
             for (const entry of entries) {
@@ -94,6 +96,12 @@ export class MetaTeamService {
                         (totalDistribution.battlesuit || 0) + 1;
                     totalDistribution.battlesuitDamage =
                         (totalDistribution.battlesuitDamage || 0) +
+                        entry.damageDealt;
+                } else if (team === MetaTeams.LAVSTODES) {
+                    totalDistribution.lavstodes =
+                        (totalDistribution.lavstodes || 0) + 1;
+                    totalDistribution.lavstodesDamage =
+                        (totalDistribution.lavstodesDamage || 0) +
                         entry.damageDealt;
                 } else {
                     totalDistribution.other =
@@ -175,6 +183,8 @@ export class MetaTeamService {
                     custodesDamage: 0,
                     battlesuit: 0,
                     battlesuitDamage: 0,
+                    lavstodes: 0,
+                    lavstodesDamage: 0,
                 };
 
                 for (const entry of entries) {
@@ -225,6 +235,13 @@ export class MetaTeamService {
                                 (totalDistribution.battlesuitDamage || 0) +
                                 entry.damageDealt;
                             break;
+                        case MetaTeams.LAVSTODES:
+                            totalDistribution.lavstodes =
+                                (totalDistribution.lavstodes || 0) + 1;
+                            totalDistribution.lavstodesDamage =
+                                (totalDistribution.lavstodesDamage || 0) +
+                                entry.damageDealt;
+                            break;
                         default:
                             totalDistribution.other =
                                 (totalDistribution.other || 0) + 1;
@@ -241,6 +258,7 @@ export class MetaTeamService {
                     totalDistribution.neuroDamage! +
                     totalDistribution.custodesDamage! +
                     totalDistribution.battlesuitDamage! +
+                    totalDistribution.lavstodesDamage! +
                     totalDistribution.otherDamage!;
 
                 if (totalDamage === 0 || totalEntries === 0) {
@@ -256,6 +274,8 @@ export class MetaTeamService {
                         custodesDamage: 0,
                         battlesuit: 0,
                         battlesuitDamage: 0,
+                        lavstodes: 0,
+                        lavstodesDamage: 0,
                         otherDamage: 0,
                     };
                     continue;
@@ -269,6 +289,8 @@ export class MetaTeamService {
                     other: (totalDistribution.other / totalEntries) * 100,
                     battlesuit:
                         (totalDistribution.battlesuit / totalEntries) * 100,
+                    lavstodes:
+                        (totalDistribution.lavstodes / totalEntries) * 100,
                     mechDamage:
                         (totalDistribution.mechDamage! / totalDamage) * 100,
                     multihitDamage:
@@ -281,6 +303,9 @@ export class MetaTeamService {
                         (totalDistribution.custodesDamage! / totalDamage) * 100,
                     battlesuitDamage:
                         (totalDistribution.battlesuitDamage! / totalDamage) *
+                        100,
+                    lavstodesDamage:
+                        (totalDistribution.lavstodesDamage! / totalDamage) *
                         100,
                 };
 

--- a/src/lib/utils/metaTeamUtils.ts
+++ b/src/lib/utils/metaTeamUtils.ts
@@ -8,6 +8,7 @@ import { META_TEAM_THRESHOLD } from "../configs/constants";
 import {
     battlesuitTeam,
     custodesTeam,
+    lavstodesTeam,
     lynchpinHeroes,
     mechTeam,
     multiHitTeam,
@@ -20,6 +21,7 @@ export interface TeamCheck {
     inMech: boolean;
     inNeuro: boolean;
     inCustodes: boolean;
+    inLavstodes: boolean;
 }
 
 /**
@@ -35,6 +37,7 @@ export function inTeamsCheck(hero: string): TeamCheck {
         inNeuro: false,
         inCustodes: false,
         inBattlesuit: false,
+        inLavstodes: false,
     };
 
     teamCheck.inMulti = multiHitTeam.includes(hero);
@@ -42,6 +45,7 @@ export function inTeamsCheck(hero: string): TeamCheck {
     teamCheck.inNeuro = neuroTeam.includes(hero);
     teamCheck.inCustodes = custodesTeam.includes(hero);
     teamCheck.inBattlesuit = battlesuitTeam.includes(hero);
+    teamCheck.inLavstodes = lavstodesTeam.includes(hero);
 
     return teamCheck;
 }
@@ -60,7 +64,7 @@ export function hasLynchpinHeroes(heroes: string[], team: string): boolean {
     }
 
     return requiredHeroes.every((requiredHero) =>
-        heroes.includes(requiredHero)
+        heroes.includes(requiredHero),
     );
 }
 
@@ -83,6 +87,7 @@ export function getMetaTeam(heroes: string[]): MetaTeams {
         neuro: 0,
         custodes: 0,
         battlesuit: 0,
+        lavstodes: 0,
     };
 
     teamCheck.forEach((check) => {
@@ -91,6 +96,7 @@ export function getMetaTeam(heroes: string[]): MetaTeams {
         if (check.inNeuro) distribution.neuro++;
         if (check.inCustodes) distribution.custodes++;
         if (check.inBattlesuit) distribution.battlesuit++;
+        if (check.inLavstodes) distribution.lavstodes++;
     });
 
     if (
@@ -108,6 +114,11 @@ export function getMetaTeam(heroes: string[]): MetaTeams {
         hasLynchpinHeroes(heroes, MetaTeams.NEURO)
     ) {
         return MetaTeams.NEURO;
+    } else if (
+        distribution.lavstodes >= META_TEAM_THRESHOLD &&
+        hasLynchpinHeroes(heroes, MetaTeams.LAVSTODES)
+    ) {
+        return MetaTeams.LAVSTODES;
     } else if (
         distribution.custodes >= META_TEAM_THRESHOLD &&
         hasLynchpinHeroes(heroes, MetaTeams.CUSTODES)
@@ -141,6 +152,7 @@ export function getMetaTeams(heroes: string[]): MetaComps {
         neuro: 0,
         custodes: 0,
         battlesuit: 0,
+        lavstodes: 0,
     };
 
     const retval: MetaComps = {
@@ -149,6 +161,7 @@ export function getMetaTeams(heroes: string[]): MetaComps {
         neuro: false,
         custodes: false,
         battlesuit: false,
+        lavstodes: false,
     };
 
     teamCheck.forEach((check) => {
@@ -157,6 +170,7 @@ export function getMetaTeams(heroes: string[]): MetaComps {
         if (check.inNeuro) distribution.neuro++;
         if (check.inCustodes) distribution.custodes++;
         if (check.inBattlesuit) distribution.battlesuit++;
+        if (check.inLavstodes) distribution.lavstodes++;
     });
 
     if (
@@ -188,6 +202,12 @@ export function getMetaTeams(heroes: string[]): MetaComps {
         hasLynchpinHeroes(heroes, MetaTeams.BATTLESUIT)
     ) {
         retval.battlesuit = true;
+    }
+    if (
+        distribution.lavstodes >= META_TEAM_THRESHOLD &&
+        hasLynchpinHeroes(heroes, MetaTeams.LAVSTODES)
+    ) {
+        retval.lavstodes = true;
     }
 
     return retval;

--- a/src/models/enums/MetaTeams.ts
+++ b/src/models/enums/MetaTeams.ts
@@ -4,5 +4,6 @@ export enum MetaTeams {
     NEURO = "Neuro",
     CUSTODES = "Custodes",
     BATTLESUIT = "Battlesuit",
+    LAVSTODES = "Lavstodes",
     OTHER = "Other",
 }

--- a/src/models/types/MetaComps.ts
+++ b/src/models/types/MetaComps.ts
@@ -4,4 +4,5 @@ export interface MetaComps {
     neuro: boolean;
     custodes: boolean;
     battlesuit: boolean;
+    lavstodes: boolean;
 }

--- a/src/models/types/TeamDistribution.ts
+++ b/src/models/types/TeamDistribution.ts
@@ -9,6 +9,8 @@ export interface TeamDistribution {
     custodesDamage?: number;
     battlesuit: number;
     battlesuitDamage?: number;
+    lavstodes: number;
+    lavstodesDamage?: number;
     other: number;
     otherDamage?: number;
 }

--- a/src/test/utils/metaTeamUtilsSuite.test.ts
+++ b/src/test/utils/metaTeamUtilsSuite.test.ts
@@ -24,6 +24,7 @@ describe("metaTeamUtils - Algebra", () => {
             neuro: 0,
             custodes: 0,
             battlesuit: 0,
+            lavstodes: 0,
         };
         heroes.forEach((hero) => {
             const res = inTeamsCheck(hero);
@@ -32,6 +33,7 @@ describe("metaTeamUtils - Algebra", () => {
             result.neuro += res.inNeuro ? 1 : 0;
             result.custodes += res.inCustodes ? 1 : 0;
             result.battlesuit += res.inBattlesuit ? 1 : 0;
+            result.lavstodes += res.inLavstodes ? 1 : 0;
         });
         expect(result).toEqual({
             multi: 3,
@@ -39,6 +41,7 @@ describe("metaTeamUtils - Algebra", () => {
             neuro: 1,
             custodes: 2,
             battlesuit: 2,
+            lavstodes: 2,
         });
     });
 
@@ -126,6 +129,19 @@ describe("metaTeamUtils - Algebra", () => {
         expect(battlesuitTeam).toBe(1);
     });
 
+    test("hasLynchpinHero - Should detect lavstodes lynchpins", () => {
+        const lavstodesTeamHeroes = [
+            characters.Laviscus.id,
+            characters.Kariyan.id,
+            characters.Trajann.id,
+            characters.Kharn.id,
+            characters.Dante.id,
+        ];
+        expect(
+            hasLynchpinHeroes(lavstodesTeamHeroes, MetaTeams.LAVSTODES),
+        ).toBe(true);
+    });
+
     test("getMetaTeam - Should return the correct meta team", () => {
         const multihitTeam = [
             characters.Bellator.id,
@@ -159,7 +175,7 @@ describe("metaTeamUtils - Algebra", () => {
         const custodesTeam = [
             characters.Trajann.id,
             characters.Kariyan.id,
-            characters.Ragnar.id,
+            characters.Abaddon.id,
             characters.Kharn.id,
             characters.Dante.id,
         ];
@@ -198,6 +214,17 @@ describe("metaTeamUtils - Algebra", () => {
         expect(getMetaTeam(battlesuitTeam)).toEqual(MetaTeams.BATTLESUIT);
     });
 
+    test("getMetaTeam - Should return LAVSTODES for lavstodes meta team", () => {
+        const lavstodesTeamHeroes = [
+            characters.Laviscus.id,
+            characters.Kariyan.id,
+            characters.Trajann.id,
+            characters.Kharn.id,
+            characters.Dante.id,
+        ];
+        expect(getMetaTeam(lavstodesTeamHeroes)).toEqual(MetaTeams.LAVSTODES);
+    });
+
     test("getMetaTeams - Should return correct meta teams present in hero list", () => {
         const admechTeam = [
             characters.ExitorRho.id,
@@ -210,7 +237,7 @@ describe("metaTeamUtils - Algebra", () => {
         const custodesTeam = [
             characters.Trajann.id,
             characters.Kariyan.id,
-            characters.Ragnar.id,
+            characters.Abaddon.id,
             characters.Kharn.id,
             characters.Dante.id,
         ];
@@ -245,6 +272,7 @@ describe("metaTeamUtils - Algebra", () => {
             neuro: false,
             custodes: false,
             battlesuit: false,
+            lavstodes: false,
         });
 
         expect(getMetaTeams(custodesTeam)).toEqual({
@@ -253,6 +281,7 @@ describe("metaTeamUtils - Algebra", () => {
             neuro: false,
             custodes: true,
             battlesuit: false,
+            lavstodes: false,
         });
 
         expect(getMetaTeams(multihitTeam)).toEqual({
@@ -261,6 +290,7 @@ describe("metaTeamUtils - Algebra", () => {
             neuro: false,
             custodes: false,
             battlesuit: false,
+            lavstodes: false,
         });
 
         expect(getMetaTeams(battleSuitTeam)).toEqual({
@@ -269,6 +299,7 @@ describe("metaTeamUtils - Algebra", () => {
             neuro: false,
             custodes: false,
             battlesuit: true,
+            lavstodes: false,
         });
 
         expect(getMetaTeams(nonsenseTeam)).toEqual({
@@ -277,6 +308,7 @@ describe("metaTeamUtils - Algebra", () => {
             neuro: false,
             custodes: false,
             battlesuit: false,
+            lavstodes: false,
         });
     });
 });


### PR DESCRIPTION
This pull request introduces a new meta team called "Lavstodes" and integrates it throughout the codebase. The changes include updating team configuration, hero detection logic, chart generation, and test coverage to support the new team. Additionally, new characters are added, and the logic for meta team assignment and statistics is extended to account for Lavstodes.

**Lavstodes Team Integration**

* Added a new team, `lavstodesTeam`, to `metaTeamConfig.ts`, including the relevant characters and lynchpin hero definitions. [[1]](diffhunk://#diff-c8ab40cda8d8e077acd8e0829da8fb33bf091a0b7143c3a419b81bfc2afac3d6L53-R79) [[2]](diffhunk://#diff-c8ab40cda8d8e077acd8e0829da8fb33bf091a0b7143c3a419b81bfc2afac3d6R108-R112)
* Updated the `MetaTeams` enum to include `LAVSTODES`.
* Extended `MetaComps` and `TeamDistribution` types to include `lavstodes` and `lavstodesDamage`. [[1]](diffhunk://#diff-97f889eb8da349412ae47d86a69b5e21a8a30191b2e958bd6c67f53b97bed878R7) [[2]](diffhunk://#diff-97da2e6f1ee033fe8396b3b2a7d642571331aa9fa97fa16b01644522938602bbR12-R13)

**Meta Team Detection Logic**

* Updated `metaTeamUtils.ts` to:
    - Track Lavstodes membership in `TeamCheck`, `getMetaTeam`, and `getMetaTeams`. [[1]](diffhunk://#diff-bfacc5c432e0a2af5658a3b51021b6ef31b211c74692ceb69ff83d32b97c0f0aR24) [[2]](diffhunk://#diff-bfacc5c432e0a2af5658a3b51021b6ef31b211c74692ceb69ff83d32b97c0f0aR40-R48) [[3]](diffhunk://#diff-bfacc5c432e0a2af5658a3b51021b6ef31b211c74692ceb69ff83d32b97c0f0aR90) [[4]](diffhunk://#diff-bfacc5c432e0a2af5658a3b51021b6ef31b211c74692ceb69ff83d32b97c0f0aR99) [[5]](diffhunk://#diff-bfacc5c432e0a2af5658a3b51021b6ef31b211c74692ceb69ff83d32b97c0f0aR117-R121) [[6]](diffhunk://#diff-bfacc5c432e0a2af5658a3b51021b6ef31b211c74692ceb69ff83d32b97c0f0aR155) [[7]](diffhunk://#diff-bfacc5c432e0a2af5658a3b51021b6ef31b211c74692ceb69ff83d32b97c0f0aR164) [[8]](diffhunk://#diff-bfacc5c432e0a2af5658a3b51021b6ef31b211c74692ceb69ff83d32b97c0f0aR173) [[9]](diffhunk://#diff-bfacc5c432e0a2af5658a3b51021b6ef31b211c74692ceb69ff83d32b97c0f0aR206-R211)
    - Ensure Lavstodes lynchpin heroes are checked for team validation.

**Chart and Statistics Updates**

* Updated `MetaTeamService` to aggregate and calculate Lavstodes team and damage statistics, including in percentage breakdowns. [[1]](diffhunk://#diff-56302412965bbb2d13678a76b1fe5cf94e2a16539440fd6a595e4a5099f13289R56-R57) [[2]](diffhunk://#diff-56302412965bbb2d13678a76b1fe5cf94e2a16539440fd6a595e4a5099f13289R100-R105) [[3]](diffhunk://#diff-56302412965bbb2d13678a76b1fe5cf94e2a16539440fd6a595e4a5099f13289R186-R187) [[4]](diffhunk://#diff-56302412965bbb2d13678a76b1fe5cf94e2a16539440fd6a595e4a5099f13289R238-R244) [[5]](diffhunk://#diff-56302412965bbb2d13678a76b1fe5cf94e2a16539440fd6a595e4a5099f13289R261) [[6]](diffhunk://#diff-56302412965bbb2d13678a76b1fe5cf94e2a16539440fd6a595e4a5099f13289R277-R278) [[7]](diffhunk://#diff-56302412965bbb2d13678a76b1fe5cf94e2a16539440fd6a595e4a5099f13289R292-R293) [[8]](diffhunk://#diff-56302412965bbb2d13678a76b1fe5cf94e2a16539440fd6a595e4a5099f13289R307-R309)
* Updated `ChartService` to display Lavstodes data in charts, including labels, values, and color assignment. [[1]](diffhunk://#diff-bbfb5439597dbfd7db536a6ce84379f4b9c0dacfd916f07ecb7470f7192bf0ebR530-R541) [[2]](diffhunk://#diff-bbfb5439597dbfd7db536a6ce84379f4b9c0dacfd916f07ecb7470f7192bf0ebR553) [[3]](diffhunk://#diff-bbfb5439597dbfd7db536a6ce84379f4b9c0dacfd916f07ecb7470f7192bf0ebR565) [[4]](diffhunk://#diff-bbfb5439597dbfd7db536a6ce84379f4b9c0dacfd916f07ecb7470f7192bf0ebR577) [[5]](diffhunk://#diff-bbfb5439597dbfd7db536a6ce84379f4b9c0dacfd916f07ecb7470f7192bf0ebR586)

**Character Configuration**

* Added new characters, including those for the Lavstodes and Leagues of Votann teams, to `charactersConfig.ts`. [[1]](diffhunk://#diff-5fe5bdf39f5088b661a2b258ac17f2d0cf50b66d97372fd82a87dc176f4e06f2R102) [[2]](diffhunk://#diff-5fe5bdf39f5088b661a2b258ac17f2d0cf50b66d97372fd82a87dc176f4e06f2R148-R151)

**Test Coverage**

* Extended the test suite in `metaTeamUtilsSuite.test.ts` to cover Lavstodes logic, including algebraic checks and lynchpin detection. [[1]](diffhunk://#diff-361b66a286dad8795d6cca8944ea7a742967a14f7f324f3dbb76203bfa5ac173R27) [[2]](diffhunk://#diff-361b66a286dad8795d6cca8944ea7a742967a14f7f324f3dbb76203bfa5ac173R36-R44) [[3]](diffhunk://#diff-361b66a286dad8795d6cca8944ea7a742967a14f7f324f3dbb76203bfa5ac173R132-R144)

These changes ensure the new Lavstodes team is fully supported across configuration, detection, statistics, charting, and testing.