### PR TITLE
feat: add lavstodes definition to memberstatsperseason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.0]
+
+### Added
+
+- Added missing Lavstodes display in `/member-stats-per-season` command
+
 ## [1.23.0]
 
 This patch updates the meta team config to better represent the current picture of the meta teams. I've also added a little raffle code you can use in the anniversary raffle over at the bottom of https://tacticusgame.com/. You can find the raffle code at the bottom of all commands or over at https://hominabot.com

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homina",
     "main": "index.ts",
-    "version": "1.23.0",
+    "version": "1.24.0",
     "module": "index.ts",
     "type": "module",
     "private": true,

--- a/src/commands/guild-raid/memberStatsBySeason.ts
+++ b/src/commands/guild-raid/memberStatsBySeason.ts
@@ -133,7 +133,7 @@ export async function renderMemberStatsBySeasonMessage(
             embed
                 .setTitle(`Member stats for season ${season} (current season)`)
                 .setDescription(
-                    "**Teams:** MH = Multihit, AM = Admech, NE = Neuro, CU = Custodes, BS = Battlesuit, OT = Other" +
+                    "**Teams:** MH = Multihit, AM = Admech, NE = Neuro, CU = Custodes, BS = Battlesuit, LA = Lavstodes, OT = Other" +
                         (rarity ? `\n**Rarity filter:** ${rarity}` : ""),
                 );
         }
@@ -146,7 +146,7 @@ export async function renderMemberStatsBySeasonMessage(
                 (stats.totalTokens > 0 ? stats.totalTokens : 1)
             ).toLocaleString("default", { maximumFractionDigits: 1 });
             const d = stats.distribution;
-            const teamLine = `MH: ${fmt(d.multihit)} AM: ${fmt(d.mech)} NE: ${fmt(d.neuro)} CU: ${fmt(d.custodes)} BS: ${fmt(d.battlesuit)} OT: ${fmt(d.other)}`;
+            const teamLine = `MH: ${fmt(d.multihit)} AM: ${fmt(d.mech)} NE: ${fmt(d.neuro)} CU: ${fmt(d.custodes)} BS: ${fmt(d.battlesuit)} LA: ${fmt(d.lavstodes)} OT: ${fmt(d.other)}`;
 
             embed.addFields({
                 name: stats.username,
@@ -318,7 +318,7 @@ export async function execute(interaction: ChatInputCommandInteraction) {
                 "See the detailed statistics for each member in the specified season.\n\n" +
                     ":family: - Team distribution used by the player\n" +
                     ":bar_chart: - Percentage of total damage dealt by meta teams\n\n" +
-                    "**Teams:** MH = Multihit, AM = Admech, NE = Neuro, CU = Custodes, BS = Battlesuit, OT = Other\n\n" +
+                    "**Teams:** MH = Multihit, AM = Admech, NE = Neuro, CU = Custodes, BS = Battlesuit, LA = Lavstodes, OT = Other\n\n" +
                     "**Includes primes:** Yes",
             )
             .setFields({
@@ -352,8 +352,8 @@ export async function execute(interaction: ChatInputCommandInteraction) {
 
             const d = stats.distribution;
             const formattedTeamDistribution =
-                `:family:  MH: ${fmt(d.multihit)} AM: ${fmt(d.mech)} NE: ${fmt(d.neuro)} CU: ${fmt(d.custodes)} BS: ${fmt(d.battlesuit)} OT: ${fmt(d.other)}\n` +
-                `:bar_chart: MH: ${fmt(d.multihitDamage)} AM: ${fmt(d.mechDamage)} NE: ${fmt(d.neuroDamage)} CU: ${fmt(d.custodesDamage)} BS: ${fmt(d.battlesuitDamage)} OT: ${fmt(d.otherDamage)}`;
+                `:family:  MH: ${fmt(d.multihit)} AM: ${fmt(d.mech)} NE: ${fmt(d.neuro)} CU: ${fmt(d.custodes)} BS: ${fmt(d.battlesuit)} LA: ${fmt(d.lavstodes)} OT: ${fmt(d.other)}\n` +
+                `:bar_chart: MH: ${fmt(d.multihitDamage)} AM: ${fmt(d.mechDamage)} NE: ${fmt(d.neuroDamage)} CU: ${fmt(d.custodesDamage)} BS: ${fmt(d.battlesuitDamage)} LA: ${fmt(d.lavstodesDamage)} OT: ${fmt(d.otherDamage)}`;
 
             pagination.addFields({
                 name: `${stats.username}`,


### PR DESCRIPTION
This pull request updates the team distribution statistics in the `memberStatsBySeason` command to include a new team, "Lavstodes" (abbreviated as LA), throughout the user interface and statistics breakdowns. This ensures consistency and visibility for the new team in all relevant outputs.

**Team Distribution Updates:**

* Added "Lavstodes" (LA) to the team abbreviation legend in all user-facing descriptions and embeds, ensuring users are aware of the new team. [[1]](diffhunk://#diff-0746e6062101e01c6354fc6bf97c58ef29b8332a5c3e2d4c307b6f42c7ed16b5L136-R136) [[2]](diffhunk://#diff-0746e6062101e01c6354fc6bf97c58ef29b8332a5c3e2d4c307b6f42c7ed16b5L321-R321)
* Updated the team statistics lines to include both the count and damage statistics for "Lavstodes" in all relevant output fields and summaries. [[1]](diffhunk://#diff-0746e6062101e01c6354fc6bf97c58ef29b8332a5c3e2d4c307b6f42c7ed16b5L149-R149) [[2]](diffhunk://#diff-0746e6062101e01c6354fc6bf97c58ef29b8332a5c3e2d4c307b6f42c7ed16b5L355-R356)